### PR TITLE
Fix for #26

### DIFF
--- a/src/main/bin/gremlin.sh
+++ b/src/main/bin/gremlin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-case `uname -o` in
-  Cygwin)
+case `uname` in
+  CYGWIN*)
     CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /;/g')
     ;;
   *)

--- a/src/main/bin/gremlin.sh
+++ b/src/main/bin/gremlin.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
+case `uname -o` in
+  Cygwin)
+    CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /;/g')
+    ;;
+  *)
+    CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
+esac
 #echo $CP
 
 # Find Java


### PR DESCRIPTION
I'm using case here since it was used in another script I have that can be expanded to detect other OSs and handle other peculiarities. It may also be better to extract the file separation character into a variable so that there is only one "CP=..." line.
