### PR TITLE
Eclipse warnings cleanup

### DIFF
--- a/doc/eclipse-formatter.xml
+++ b/doc/eclipse-formatter.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="12">
+<profile kind="CodeFormatterProfile" name="Titan" version="12">
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+</profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -356,5 +356,34 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <!-- Suppress enforcer plugin warning from m2e - plugin is inherited from Sonatype parent pom -->
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-enforcer-plugin</artifactId>
+                                        <versionRange>[1.0,)</versionRange>
+                                        <goals>
+                                            <goal>enforce</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/src/main/java/com/thinkaurelius/titan/core/GraphStorageException.java
+++ b/src/main/java/com/thinkaurelius/titan/core/GraphStorageException.java
@@ -1,7 +1,5 @@
 package com.thinkaurelius.titan.core;
 
-import com.thinkaurelius.titan.util.datastructures.ExceptionUtil;
-
 /**
  * Exception thrown in the storage layer of the graph database.
  * 

--- a/src/main/java/com/thinkaurelius/titan/core/InvalidElementException.java
+++ b/src/main/java/com/thinkaurelius/titan/core/InvalidElementException.java
@@ -10,6 +10,8 @@ package com.thinkaurelius.titan.core;
  */
 public class InvalidElementException extends GraphDatabaseException {
 
+    private static final long serialVersionUID = -6810739250149922561L;
+
     private final TitanVertex element;
 
     /**
@@ -30,7 +32,7 @@ public class InvalidElementException extends GraphDatabaseException {
     public TitanVertex getElement() {
         return element;
     }
-    
+
     @Override
     public String toString() {
         return super.toString() + " [" + element.toString() + "]";

--- a/src/main/java/com/thinkaurelius/titan/core/TitanFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/core/TitanFactory.java
@@ -3,8 +3,6 @@ package com.thinkaurelius.titan.core;
 import com.thinkaurelius.titan.graphdb.blueprints.TitanInMemoryBlueprintsGraph;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.graphdb.database.StandardTitanGraph;
-import com.thinkaurelius.titan.graphdb.transaction.InMemoryTitanGraph;
-import com.thinkaurelius.titan.graphdb.transaction.TransactionConfig;
 import org.apache.commons.configuration.Configuration;
 
 /**

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleydb/je/BerkeleyJEStorageAdapter.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleydb/je/BerkeleyJEStorageAdapter.java
@@ -1,6 +1,5 @@
 package com.thinkaurelius.titan.diskstorage.berkeleydb.je;
 
-import com.thinkaurelius.titan.diskstorage.util.KeyValueStorageManager;
 import com.thinkaurelius.titan.diskstorage.util.KeyValueStorageManagerAdapter;
 import org.apache.commons.configuration.Configuration;
 

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleydb/je/BerkeleyJEStorageManager.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleydb/je/BerkeleyJEStorageManager.java
@@ -8,7 +8,6 @@ import com.thinkaurelius.titan.diskstorage.util.*;
 
 import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.*;
 
-import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.util.system.IOUtils;
 import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraThriftStorageManager.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraThriftStorageManager.java
@@ -1,7 +1,5 @@
 package com.thinkaurelius.titan.diskstorage.cassandra;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thriftpool/CTConnectionFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thriftpool/CTConnectionFactory.java
@@ -158,7 +158,7 @@ public class CTConnectionFactory implements KeyedPoolableObjectFactory {
                 		((e instanceof InvalidRequestException) ? 
                 				((InvalidRequestException) e).getWhy() : e.getMessage()));
             }
-            
+            @SuppressWarnings("unused")
             int nodeCount = 0;
             // Check schema version
             UUID benchmark = UUID.fromString(currentVersionId);
@@ -168,7 +168,7 @@ public class CTConnectionFactory implements KeyedPoolableObjectFactory {
             		nodeCount += versions.get(version).size();
             		continue;
             	}
-            	
+
             	UUID uuid = UUID.fromString(version);
             	ByteBuffer uuidBB = ti.decompose(uuid);
                 if (-1 < ti.compare(uuidBB, benchmarkBB)) {

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseOrderedKeyColumnValueStore.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseOrderedKeyColumnValueStore.java
@@ -29,7 +29,6 @@ import com.thinkaurelius.titan.diskstorage.OrderedKeyColumnValueStore;
 import com.thinkaurelius.titan.diskstorage.TransactionHandle;
 import com.thinkaurelius.titan.diskstorage.locking.LocalLockMediator;
 import com.thinkaurelius.titan.diskstorage.util.SimpleLockConfig;
-import com.thinkaurelius.titan.diskstorage.util.TimestampProvider;
 import com.thinkaurelius.titan.diskstorage.writeaggregation.MultiWriteKeyColumnValueStore;
 
 /**

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/util/KeyValueStorageManagerAdapter.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/util/KeyValueStorageManagerAdapter.java
@@ -13,15 +13,16 @@ import java.util.Iterator;
 public class KeyValueStorageManagerAdapter implements StorageManager {
 
     public static final String KEYLENGTH_NAMESPACE = "keylengths";
-    
-	private final KeyValueStorageManager manager;
-	
-	private final ImmutableMap<String,Integer> keyLengths;
-	
-	public KeyValueStorageManagerAdapter(KeyValueStorageManager manager, Configuration config) {
-		this.manager = manager;
-		Configuration keylen = config.subset(KEYLENGTH_NAMESPACE);
+
+    private final KeyValueStorageManager manager;
+
+    private final ImmutableMap<String,Integer> keyLengths;
+
+    public KeyValueStorageManagerAdapter(KeyValueStorageManager manager, Configuration config) {
+        this.manager = manager;
+        Configuration keylen = config.subset(KEYLENGTH_NAMESPACE);
         ImmutableMap.Builder<String,Integer> builder = ImmutableMap.builder();
+        @SuppressWarnings("unchecked")
         Iterator<String> keys = keylen.getKeys();
         while(keys.hasNext()) {
             String name = keys.next();
@@ -30,9 +31,8 @@ public class KeyValueStorageManagerAdapter implements StorageManager {
             builder.put(name,Integer.valueOf(length));
         }
         keyLengths = builder.build();
-        
-	}
-		
+    }
+
 	@Override
 	public TransactionHandle beginTransaction() {
 		return manager.beginTransaction();

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/util/LocalIDManager.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/util/LocalIDManager.java
@@ -3,7 +3,6 @@ package com.thinkaurelius.titan.diskstorage.util;
 import cern.colt.map.AbstractIntIntMap;
 import cern.colt.map.OpenIntIntHashMap;
 import com.google.common.base.Preconditions;
-import com.thinkaurelius.titan.core.GraphDatabaseException;
 import com.thinkaurelius.titan.core.GraphStorageException;
 
 import java.io.*;

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/util/OrderedKeyValueStoreAdapter.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/util/OrderedKeyValueStoreAdapter.java
@@ -113,6 +113,7 @@ public class OrderedKeyValueStoreAdapter extends KeyValueStoreAdapter implements
 		
 	}
 	
+	@SuppressWarnings("unused")
 	private class KeyColumnSliceSelector implements KeySelector {
 
 		private final ByteBuffer keyStart;

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/util/ReadOnlyOrderedKeyValueStore.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/util/ReadOnlyOrderedKeyValueStore.java
@@ -6,7 +6,6 @@ import com.thinkaurelius.titan.diskstorage.TransactionHandle;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Map;
 
 public class ReadOnlyOrderedKeyValueStore extends ReadOnlyKeyValueStore implements OrderedKeyColumnValueStore{
 

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/writeaggregation/BatchStoreMutator.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/writeaggregation/BatchStoreMutator.java
@@ -1,13 +1,11 @@
 package com.thinkaurelius.titan.diskstorage.writeaggregation;
 
-import com.thinkaurelius.titan.diskstorage.Entry;
 import com.thinkaurelius.titan.diskstorage.TransactionHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/writeaggregation/StoreMutator.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/writeaggregation/StoreMutator.java
@@ -1,8 +1,6 @@
 package com.thinkaurelius.titan.diskstorage.writeaggregation;
 
 import com.thinkaurelius.titan.diskstorage.Entry;
-import com.thinkaurelius.titan.diskstorage.LockKeyColumnValueStore;
-
 import java.nio.ByteBuffer;
 import java.util.List;
 

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjacencyList.java
@@ -11,8 +11,6 @@ import java.util.NoSuchElementException;
 
 public class ArrayAdjacencyList implements AdjacencyList {
 
-	private static final long serialVersionUID = -2868708972683152295L;
-
 	private final ArrayAdjListFactory factory;
 	private InternalRelation[] contents;
 

--- a/src/main/java/com/thinkaurelius/titan/graphdb/blueprints/TitanFeatures.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/blueprints/TitanFeatures.java
@@ -1,6 +1,5 @@
 package com.thinkaurelius.titan.graphdb.blueprints;
 
-import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.tinkerpop.blueprints.Features;
 
 /**
@@ -8,7 +7,8 @@ import com.tinkerpop.blueprints.Features;
  */
 
 public class TitanFeatures {
-    
+
+    @SuppressWarnings("deprecation")
     public static Features getBaselineTitanFeatures() {
         Features features = new Features();
         features.supportsDuplicateEdges = true;
@@ -44,5 +44,5 @@ public class TitanFeatures {
         features.checkCompliance();
         return features;
     }
-    
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -45,10 +45,11 @@ import java.util.*;
  *
  */
 public class GraphDatabaseConfiguration {
-	
-	private static final Logger log =
-		LoggerFactory.getLogger(GraphDatabaseConfiguration.class);
 
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(GraphDatabaseConfiguration.class);
+
+    @SuppressWarnings("serial")
     private static final Map<String,Class<? extends StorageManager>> preregisteredStorageManagers = new HashMap<String,Class<? extends StorageManager>>() {{
         put("local", BerkeleyJEStorageAdapter.class);
         put("berkeleyje", BerkeleyJEStorageAdapter.class);
@@ -57,7 +58,8 @@ public class GraphDatabaseConfiguration {
         put("astyanax", AstyanaxStorageManager.class);
     }};
 
-    private static final Map<String,DefaultTypeMaker> preregisteredAutoType = new HashMap<String,DefaultTypeMaker>() {{
+    @SuppressWarnings("serial")
+	private static final Map<String,DefaultTypeMaker> preregisteredAutoType = new HashMap<String,DefaultTypeMaker>() {{
         put("blueprints", BlueprintsDefaultTypeMaker.INSTANCE);
     }};
 
@@ -117,7 +119,7 @@ public class GraphDatabaseConfiguration {
      */
     public static final String AUTO_TYPE_KEY = "autotype";
     public static final String AUTO_TYPE_DEFAULT = "blueprints";
-    
+
     private static final String ID_RANDOMIZER_BITS_KEY = "id-random-bits";
     private static final int ID_RANDOMIZER_BITS_DEFAULT = 0;
 
@@ -183,16 +185,14 @@ public class GraphDatabaseConfiguration {
 
     private static final String STORAGE_EDGESTORE_DEFAULT = "edgestore";
     private static final String STORAGE_PROPERTYINDEX_DEFAULT = "propertyindex";
-    
-    
+
     private final Configuration configuration;
-    
+
     private boolean readOnly;
     private boolean flushIDs;
     private boolean batchLoading;
     private DefaultTypeMaker defaultTypeMaker;
-    
-    
+
     public GraphDatabaseConfiguration(Configuration config) {
         Preconditions.checkNotNull(config);
         this.configuration = config;
@@ -251,16 +251,16 @@ public class GraphDatabaseConfiguration {
     public boolean hasBufferMutations() {
         return configuration.getInt(BUFFER_SIZE_KEY, BUFFER_SIZE_DEFAULT)>0;
     }
-    
+
     public int getBufferSize() {
         int size = configuration.getInt(BUFFER_SIZE_KEY, BUFFER_SIZE_DEFAULT);
         Preconditions.checkArgument(size>0,"Buffer size must be positive");
         return size;
     }
-    
 
     public static List<RegisteredAttributeClass<?>> getRegisteredAttributeClasses(Configuration config) {
         List<RegisteredAttributeClass<?>> all = new ArrayList<RegisteredAttributeClass<?>>();
+        @SuppressWarnings("unchecked")
         Iterator<String> iter = config.getKeys();
         while (iter.hasNext()) {
             String key = iter.next();
@@ -280,8 +280,8 @@ public class GraphDatabaseConfiguration {
                 if (config.containsKey(SERIALIZER_PREFIX+position)) {
                     String serializername = config.getString(SERIALIZER_PREFIX+position);
                     try {
-                        Class sclass = Class.forName(serializername);
-                        serializer = (AttributeSerializer)sclass.newInstance();
+                        Class<?> sclass = Class.forName(serializername);
+                        serializer = (AttributeSerializer<?>)sclass.newInstance();
                     } catch (ClassNotFoundException e) {
                         throw new IllegalArgumentException("Could not find serializer class" + serializername);
                     } catch (InstantiationException e) {
@@ -290,6 +290,7 @@ public class GraphDatabaseConfiguration {
                         throw new IllegalArgumentException("Could not instantiate serializer class" + serializername,e);
                     }
                 }
+                @SuppressWarnings({"unchecked","rawtypes"})
                 RegisteredAttributeClass reg = new RegisteredAttributeClass(clazz,serializer,position);
                 for (int i=0;i<all.size();i++) {
                     if (all.get(i).equals(reg)) {
@@ -331,8 +332,8 @@ public class GraphDatabaseConfiguration {
         }
 
         try {
-            Class clazz = Class.forName(clazzname);
-            Constructor constructor = clazz.getConstructor(Configuration.class);
+            Class<?> clazz = Class.forName(clazzname);
+            Constructor<?> constructor = clazz.getConstructor(Configuration.class);
             StorageManager storage = (StorageManager)constructor.newInstance(storageconfig);
             return storage;
         } catch (ClassNotFoundException e) {
@@ -406,6 +407,7 @@ public class GraphDatabaseConfiguration {
 		return getPath(getHomeDirectory());
 	}
 
+    @SuppressWarnings("unused")
 	private static File getSubDirectory(String base, String sub) {
 		File subdir = new File(base, sub);
 		if (!subdir.exists()) {
@@ -417,6 +419,7 @@ public class GraphDatabaseConfiguration {
 		return subdir;
 	}
 
+    @SuppressWarnings("unused")
 	private static String getFileName(String dir, String file) {
 		if (!dir.endsWith(File.separator)) dir = dir + File.separator;
 		return dir + file;

--- a/src/main/java/com/thinkaurelius/titan/graphdb/configuration/RegisteredAttributeClass.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/configuration/RegisteredAttributeClass.java
@@ -3,8 +3,7 @@ package com.thinkaurelius.titan.graphdb.configuration;
 import com.thinkaurelius.titan.core.AttributeSerializer;
 import com.thinkaurelius.titan.graphdb.database.serialize.Serializer;
 
-import java.io.Serializable;
-
+@SuppressWarnings("rawtypes")
 public class RegisteredAttributeClass<T> implements Comparable<RegisteredAttributeClass>{
 
     private final Class<T> type;
@@ -30,15 +29,15 @@ public class RegisteredAttributeClass<T> implements Comparable<RegisteredAttribu
 	public boolean equals(Object oth) {
 		if (this==oth) return true;
 		else if (!getClass().isInstance(oth)) return false;
-		return type.equals(((RegisteredAttributeClass<?>)oth).type) || position==((RegisteredAttributeClass)oth).position;
+		return type.equals(((RegisteredAttributeClass<?>)oth).type) || position==((RegisteredAttributeClass<?>)oth).position;
 	}
 
     @Override
     public String toString() {
         return type.toString() + "#" + position;
     }
-    
-    @Override
+
+	@Override
     public int compareTo(RegisteredAttributeClass registeredAttributeClass) {
         return position - registeredAttributeClass.position;
     }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/StandardTitanGraph.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/StandardTitanGraph.java
@@ -384,7 +384,7 @@ public class StandardTitanGraph extends TitanBlueprintsGraph implements Internal
                         if (constraints.containsKey(keysig[i])) {
                             Object iv = constraints.get(keysig[i]);
                             applicableConstraints.add(iv);
-                            if (iv!=null && (iv instanceof AtomicInterval) && ((AtomicInterval)iv).isRange()) {
+                            if (iv!=null && (iv instanceof AtomicInterval) && ((AtomicInterval<?>)iv).isRange()) {
                                 isRange=true;
                                 break;
                             }
@@ -408,7 +408,7 @@ public class StandardTitanGraph extends TitanBlueprintsGraph implements Internal
                             //Write all applicable key constraints
                             for (Object iv : applicableConstraints) {
                                 if (iv instanceof AtomicInterval) {
-                                    AtomicInterval interval = (AtomicInterval)iv;
+                                    AtomicInterval<?> interval = (AtomicInterval<?>)iv;
                                     if (interval.isPoint()) {
                                         start.writeObject(interval.getStartPoint());
                                         if (isRange) end.writeObject(interval.getStartPoint());
@@ -492,13 +492,12 @@ public class StandardTitanGraph extends TitanBlueprintsGraph implements Internal
     private List<Entry> appendResults(ByteBuffer key, ByteBuffer columnStart, ByteBuffer columnEnd,
                                       List<Entry> entries, LimitTracker limit, TransactionHandle txh) {
 		if (limit.limitExhausted()) return null;
-		List<Entry> results = null;
-        results = edgeStore.getSlice(key, columnStart, columnEnd, limit.getLimit(), txh);
+		List<Entry> results = edgeStore.getSlice(key, columnStart, columnEnd, limit.getLimit(), txh);
         limit.retrieved(results.size());
 
-		if (results==null) return null;
-		else if (entries==null) return results;
-		else {
+		if (entries==null) {
+			return results;
+		} else {
 			entries.addAll(results);
 			return entries;
 		}

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/DoubleSerializer.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/DoubleSerializer.java
@@ -6,16 +6,14 @@ import java.nio.ByteBuffer;
 
 public class DoubleSerializer implements AttributeSerializer<Double> {
 
-	private static final long serialVersionUID = -1719511496523862718L;
-
     public static final int DECIMALS = 6;
     private static int MULTIPLIER = 0;
-    
+
     static {
         MULTIPLIER =1;
         for (int i=0;i<DECIMALS;i++) MULTIPLIER *=10;
     }
-    
+
 	@Override
 	public Double read(ByteBuffer buffer) {
 		long convert = buffer.getLong();

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/FloatSerializer.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/FloatSerializer.java
@@ -6,9 +6,6 @@ import java.nio.ByteBuffer;
 
 public class FloatSerializer implements AttributeSerializer<Float> {
 
-	private static final long serialVersionUID = -1719511423423862718L;
-
-
     public static final int DECIMALS = 3;
     private static int MULTIPLIER = 0;
 

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/IntegerSerializer.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/IntegerSerializer.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 
 public class IntegerSerializer implements AttributeSerializer<Integer> {
 
+    @SuppressWarnings("unused")
 	private static final long serialVersionUID = 1174998819862504186L;
 
 	@Override

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/LongSerializer.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/LongSerializer.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 
 public class LongSerializer implements AttributeSerializer<Long> {
 
+    @SuppressWarnings("unused")
 	private static final long serialVersionUID = -8438674418838450877L;
 
 	@Override

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/kryo/KryoAttributeSerializerAdapter.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/kryo/KryoAttributeSerializerAdapter.java
@@ -6,15 +6,16 @@ import com.thinkaurelius.titan.core.AttributeSerializer;
 
 import java.nio.ByteBuffer;
 
+@SuppressWarnings({"unchecked","rawtypes"})
 public class KryoAttributeSerializerAdapter<T> extends Serializer {
 
 	private final AttributeSerializer<T> serializer;
-	
+
 	KryoAttributeSerializerAdapter(AttributeSerializer<T> serializer) {
 		Preconditions.checkNotNull(serializer);
 		this.serializer=serializer;
 	}
-	
+
 	@Override
 	public T readObjectData(ByteBuffer buffer, Class type) {
 		return serializer.read(buffer);

--- a/src/main/java/com/thinkaurelius/titan/graphdb/database/statistics/LocalGraphStatistics.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/database/statistics/LocalGraphStatistics.java
@@ -27,6 +27,7 @@ public class LocalGraphStatistics implements InternalGraphStatistics {
 	private long noRelationships;
 	private long noProperties;
 	
+	@SuppressWarnings("unchecked")
 	public LocalGraphStatistics(PropertiesConfiguration file) {
 		persistence=file;
 		//Initialize

--- a/src/main/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManager.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManager.java
@@ -61,8 +61,9 @@ public class IDManager implements IDInspector {
 	public static final long defaultGroupBits = 6;
 	
 	private static final long edgeTypeDirectionOffset=totalNoBits-edgeTypeDirectionBits;
+    @SuppressWarnings("unused")
 	private static final long edgeTypeDirectionMask  = ((1l<<edgeTypeDirectionBits)-1) << (edgeTypeDirectionOffset);
-	
+    @SuppressWarnings("unused")
 	private static final long maxDirectionID = (1l<<edgeTypeDirectionBits)-2; //Need extra number for bounding
 
 	public static final long edgeTypePaddingMask = (1l<<edgeTypePaddingBits)-1;
@@ -80,9 +81,11 @@ public class IDManager implements IDInspector {
     private final long inverseGroupIDMask;
 
 	private final long groupIDMaskTMP;
+    @SuppressWarnings("unused")
 	private final long groupIDFrontMask;
 	private final long groupIDDeltaOffset;
 	private final long edgeTypeIDBackLength;
+    @SuppressWarnings("unused")
 	private final long edgeTypeCountPartMask;
 	
 	private final long maxGroupID;

--- a/src/main/java/com/thinkaurelius/titan/graphdb/query/AtomicTitanQuery.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/query/AtomicTitanQuery.java
@@ -25,11 +25,11 @@ import java.util.Map;
 public class AtomicTitanQuery implements InternalTitanQuery {
 
     protected final InternalTitanTransaction tx;
-	private InternalTitanVertex node;
+    private InternalTitanVertex node;
     private long nodeid;
-    
+
     private boolean inMemoryRetrieval=false;
-    
+
     private Direction dir;
     protected TitanType[] types;
     private TypeGroup group;
@@ -41,7 +41,6 @@ public class AtomicTitanQuery implements InternalTitanQuery {
     private boolean queryUnmodifiable;
 
     private long limit = Long.MAX_VALUE;
-    
 
     public AtomicTitanQuery(InternalTitanTransaction tx) {
         this.tx=tx;
@@ -147,7 +146,7 @@ public class AtomicTitanQuery implements InternalTitanQuery {
         } else {
             assert etype.isPropertyKey();
             Preconditions.checkArgument(((TitanKey) etype).getDataType().isInstance(value), "Value is not an instance of the property key's data type.");
-            return withPropertyConstraint(etype,new PointInterval(value));
+            return withPropertyConstraint(etype,new PointInterval<Object>(value));
         }
     }
 
@@ -163,7 +162,7 @@ public class AtomicTitanQuery implements InternalTitanQuery {
         Preconditions.checkNotNull(start);
         Preconditions.checkNotNull(end);
         Preconditions.checkNotNull(key);
-        return withPropertyConstraint(key, new Range(start, end));
+        return withPropertyConstraint(key, new Range<T>(start, end));
     }
 
     @Override
@@ -171,13 +170,14 @@ public class AtomicTitanQuery implements InternalTitanQuery {
         if (!tx.containsType(key)) throw new IllegalArgumentException("Unknown property key: " + key);
         return interval(tx.getPropertyKey(key), start, end);
     }
-    
+
     @Override
     public<T extends Comparable<T>> TitanQuery has(String ptype, T value, Query.Compare compare) {
         if (!tx.containsType(ptype)) throw new IllegalArgumentException("Unknown property key: " + ptype);
         return has(tx.getPropertyKey(ptype),value,compare);
     }
 
+    @SuppressWarnings("unchecked")
     public<T extends Comparable<T>> TitanQuery has(TitanKey ptype, T value, Query.Compare compare) {
         Preconditions.checkNotNull(value);
         Preconditions.checkNotNull(compare);
@@ -429,6 +429,7 @@ public class AtomicTitanQuery implements InternalTitanQuery {
 		return new RemovableRelationIterator<TitanEdge>(node.getRelations(this, true).iterator());
 	}
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public Iterable<Edge> edges() {
 		edgesOnly();
@@ -498,6 +499,7 @@ public class AtomicTitanQuery implements InternalTitanQuery {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public Iterable<Vertex> vertices() {
         return (Iterable)vertexIds();

--- a/src/main/java/com/thinkaurelius/titan/graphdb/query/ComplexTitanQuery.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/query/ComplexTitanQuery.java
@@ -15,7 +15,6 @@ import java.util.*;
 
 public class ComplexTitanQuery extends AtomicTitanQuery {
 
-    
     public ComplexTitanQuery(InternalTitanVertex n) {
         super(n);
     }
@@ -55,7 +54,6 @@ public class ComplexTitanQuery extends AtomicTitanQuery {
         }
     }
 
-
     /* ---------------------------------------------------------------
       * Query Execution
       * ---------------------------------------------------------------
@@ -82,24 +80,22 @@ public class ComplexTitanQuery extends AtomicTitanQuery {
     @Override
     public Iterable<TitanProperty> properties() {
         if (isAtomic()) return super.properties();
-        else return new DisjunctiveQueryIterable(this,TitanProperty.class);
+        else return new DisjunctiveQueryIterable<TitanProperty>(this,TitanProperty.class);
     }
-
 
     @Override
     public Iterator<TitanProperty> propertyIterator() {
         if (isAtomic()) return super.propertyIterator();
-        else return new DisjunctiveQueryIterator(this,TitanProperty.class);
+        else return new DisjunctiveQueryIterator<TitanProperty>(this,TitanProperty.class);
     }
-
 
     @Override
     public Iterator<TitanEdge> edgeIterator() {
         if (isAtomic()) return super.edgeIterator();
-        else return new DisjunctiveQueryIterator(this,TitanEdge.class);
+        else return new DisjunctiveQueryIterator<TitanEdge>(this,TitanEdge.class);
     }
 
-
+    @SuppressWarnings({"unchecked","rawtypes"})
     @Override
     public Iterable<Edge> edges() {
         if (isAtomic()) return super.edges();
@@ -109,19 +105,19 @@ public class ComplexTitanQuery extends AtomicTitanQuery {
     @Override
     public Iterable<TitanEdge> titanEdges() {
         if (isAtomic()) return super.titanEdges();
-        else return new DisjunctiveQueryIterable(this,TitanEdge.class);
+        else return new DisjunctiveQueryIterable<TitanEdge>(this,TitanEdge.class);
     }
 
     @Override
     public Iterator<TitanRelation> relationIterator() {
         if (isAtomic()) return super.relationIterator();
-        else return new DisjunctiveQueryIterator(this,TitanRelation.class);
+        else return new DisjunctiveQueryIterator<TitanRelation>(this,TitanRelation.class);
     }
 
     @Override
     public Iterable<TitanRelation> relations() {
         if (isAtomic()) return super.relations();
-        else return new DisjunctiveQueryIterable(this,TitanRelation.class);
+        else return new DisjunctiveQueryIterable<TitanRelation>(this,TitanRelation.class);
     }
 
     @Override
@@ -140,6 +136,7 @@ public class ComplexTitanQuery extends AtomicTitanQuery {
         }
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public Iterable<Vertex> vertices() {
         return (Iterable)vertexIds();

--- a/src/main/java/com/thinkaurelius/titan/graphdb/query/DisjunctiveQueryIterator.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/query/DisjunctiveQueryIterator.java
@@ -40,7 +40,8 @@ public class DisjunctiveQueryIterator<T extends TitanRelation> implements Iterat
             return nextIter!=null && nextIter.hasNext();
         } else return true;
     }
-    
+
+    @SuppressWarnings("unchecked")
     private void initializeNextIter() {
         if (nextIter==null) {
             while (position<queries.size() && remainingLimit>0 && (nextIter==null || !nextIter.hasNext())) {

--- a/src/main/java/com/thinkaurelius/titan/graphdb/query/QueryUtil.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/query/QueryUtil.java
@@ -38,8 +38,8 @@ public class QueryUtil {
             if (!constraints.containsKey(key)) break;
             Object o = constraints.get(key);
             num++;
-            if (o!=null && (o instanceof AtomicInterval) && ((AtomicInterval) o).isRange()) {
-                if (((AtomicInterval)o).hasHoles()) num--; //Intervals with holes have to be filtered in memory
+            if (o!=null && (o instanceof AtomicInterval) && ((AtomicInterval<?>) o).isRange()) {
+                if (((AtomicInterval<?>)o).hasHoles()) num--; //Intervals with holes have to be filtered in memory
                 break;
             }
         }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
@@ -1,6 +1,5 @@
 package com.thinkaurelius.titan.graphdb.transaction;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
@@ -8,7 +7,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.thinkaurelius.titan.core.*;
-import com.thinkaurelius.titan.core.InvalidElementException;
 import com.thinkaurelius.titan.graphdb.blueprints.TitanBlueprintsTransaction;
 import com.thinkaurelius.titan.graphdb.database.InternalTitanGraph;
 import com.thinkaurelius.titan.graphdb.query.ComplexTitanQuery;
@@ -27,7 +25,6 @@ import com.thinkaurelius.titan.util.datastructures.Factory;
 import com.thinkaurelius.titan.util.datastructures.Maps;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
-import com.tinkerpop.blueprints.util.PropertyFilteredIterable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class AbstractTitanTx extends TitanBlueprintsTransaction implements InternalTitanTransaction {
 
+    @SuppressWarnings("unused")
 	private static final Logger log = LoggerFactory.getLogger(AbstractTitanTx.class);
 
     protected InternalTitanGraph graphdb;
@@ -315,6 +313,7 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
 		return new ComplexTitanQuery((InternalTitanVertex) getVertex(nodeid));
 	}
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public Iterable<Vertex> getVertices() {
         verifyOpen();
@@ -322,7 +321,7 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
         if (newNodes!=null) 
             iter = Iterables.concat(vertexCache.getAll(),newNodes);
         else iter = vertexCache.getAll();
-        
+
         iter = Iterables.filter(iter,new Predicate<InternalTitanVertex>() {
             @Override
             public boolean apply( InternalTitanVertex input) {
@@ -435,6 +434,7 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
 
     // #### General Indexed Properties #####
 
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Override
 	public Iterable<Vertex> getVertices(String key, Object attribute) {
         Preconditions.checkNotNull(key);

--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardPersistTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardPersistTitanTx.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class StandardPersistTitanTx extends AbstractTitanTx {
 
+    @SuppressWarnings("unused")
 	private static final Logger log = LoggerFactory.getLogger(StandardPersistTitanTx.class);
 	
 

--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/TransactionConfig.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/TransactionConfig.java
@@ -1,9 +1,7 @@
 package com.thinkaurelius.titan.graphdb.transaction;
 
 import com.thinkaurelius.titan.core.DefaultTypeMaker;
-import com.thinkaurelius.titan.graphdb.blueprints.BlueprintsDefaultTypeMaker;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /***
  * Provides functionality to configure a {@link com.thinkaurelius.titan.core.TitanTransaction}.

--- a/src/main/java/com/thinkaurelius/titan/graphdb/vertices/NewEmptyTitanVertex.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/vertices/NewEmptyTitanVertex.java
@@ -1,12 +1,5 @@
 package com.thinkaurelius.titan.graphdb.vertices;
 
-
-import com.thinkaurelius.titan.graphdb.transaction.InternalTitanTransaction;
-import com.tinkerpop.blueprints.Direction;
-import com.tinkerpop.blueprints.Vertex;
-
-import java.util.Set;
-
 public abstract class NewEmptyTitanVertex extends LoadedEmptyTitanVertex {
 
 

--- a/src/main/java/com/thinkaurelius/titan/graphdb/vertices/VertexUtil.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/vertices/VertexUtil.java
@@ -69,7 +69,7 @@ public class VertexUtil {
                                     Object attribute = ((TitanProperty)ie).getAttribute();
                                     assert attribute!=null;
                                     assert o instanceof AtomicInterval;
-                                    AtomicInterval iv = (AtomicInterval)o;
+                                    AtomicInterval<?> iv = (AtomicInterval<?>)o;
                                     if (iv.inInterval(attribute)) count++;
                                 }
                             }

--- a/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/TitanGraphConfiguration.java
+++ b/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/TitanGraphConfiguration.java
@@ -1,6 +1,5 @@
 package com.thinkaurelius.titan.tinkerpop.rexster;
 
-import com.google.common.collect.ImmutableList;
 import com.thinkaurelius.titan.core.TitanFactory;
 import com.tinkerpop.blueprints.Graph;
 import com.tinkerpop.rexster.Tokens;
@@ -33,6 +32,7 @@ public class TitanGraphConfiguration implements GraphConfiguration {
             try {
                 final Configuration titanConfigProperties = ((HierarchicalConfiguration) properties).configurationAt(Tokens.REXSTER_GRAPH_PROPERTIES);
 
+                @SuppressWarnings("unchecked")
                 final Iterator<String> titanConfigPropertiesKeys = titanConfigProperties.getKeys();
                 while (titanConfigPropertiesKeys.hasNext()) {
                     String key = titanConfigPropertiesKeys.next();

--- a/src/main/java/com/thinkaurelius/titan/util/interval/Range.java
+++ b/src/main/java/com/thinkaurelius/titan/util/interval/Range.java
@@ -169,7 +169,7 @@ public class Range<V extends Comparable<V>> implements AtomicInterval<V> {
                     eInc = o.endInclusive;
                 }
             }
-            return new Range(nstart,nend,sInc,eInc);
+            return new Range<V>(nstart,nend,sInc,eInc);
         }
     }
 

--- a/src/main/java/com/thinkaurelius/titan/util/interval/RangeWithHoles.java
+++ b/src/main/java/com/thinkaurelius/titan/util/interval/RangeWithHoles.java
@@ -61,7 +61,8 @@ public class RangeWithHoles<V extends Comparable<V>> extends Range<V> {
         return super.inInterval(obj) && !holes.contains(obj);
     }
 
-    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+	@Override
     public AtomicInterval<V> intersect(AtomicInterval<V> other) {
         AtomicInterval<V> res = super.intersect(other);
         if (res==null) return null;
@@ -81,5 +82,5 @@ public class RangeWithHoles<V extends Comparable<V>> extends Range<V> {
             return new RangeWithHoles(res.getStartPoint(),res.getEndPoint(),res.startInclusive(),res.endInclusive(),ImmutableSet.of(newholes));
         }
     }
-    
+
 }

--- a/src/test/java/com/thinkaurelius/titan/StorageSetup.java
+++ b/src/test/java/com/thinkaurelius/titan/StorageSetup.java
@@ -1,8 +1,5 @@
 package com.thinkaurelius.titan;
 
-import com.thinkaurelius.titan.core.TitanFactory;
-import com.thinkaurelius.titan.core.TitanGraph;
-import com.thinkaurelius.titan.diskstorage.cassandra.CassandraThriftStorageManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.util.system.IOUtils;
 import org.apache.commons.configuration.BaseConfiguration;

--- a/src/test/java/com/thinkaurelius/titan/TestBed.java
+++ b/src/test/java/com/thinkaurelius/titan/TestBed.java
@@ -3,8 +3,6 @@ package com.thinkaurelius.titan;
 import cern.colt.function.LongObjectProcedure;
 import cern.colt.map.AbstractLongObjectMap;
 import cern.colt.map.OpenLongObjectHashMap;
-import com.sleepycat.je.util.DbCacheSize;
-
 import java.io.IOException;
 
 public class TestBed {

--- a/src/test/java/com/thinkaurelius/titan/TitanBenchmark.java
+++ b/src/test/java/com/thinkaurelius/titan/TitanBenchmark.java
@@ -19,8 +19,7 @@ import java.util.Scanner;
  */
 
 public class TitanBenchmark {
-    
-    
+
     public static void main(String[] args) throws IOException {
         Preconditions.checkArgument(args.length==3);
         final int batchSize = Integer.parseInt(args[2]);
@@ -39,14 +38,18 @@ public class TitanBenchmark {
         StopWatch watch = new StopWatch();
         if (!skipLoading) {
             tx = g.startTransaction();
+
+            @SuppressWarnings("unused")
             TitanKey vertexid = tx.makeType().name("pid").dataType(Integer.class).
                     functional(false).indexed().unique().makePropertyKey();
             TitanKey time = tx.makeType().name("time").dataType(Integer.class).
                     functional(false).makePropertyKey();
+
+            @SuppressWarnings("unused")
             TitanLabel follows = tx.makeType().name("follows").primaryKey(time).makeEdgeLabel();
             tx.stopTransaction(TransactionalGraph.Conclusion.SUCCESS);
 
-            BatchGraph loader = new BatchGraph(g, BatchGraph.IdType.NUMBER, batchSize);
+            BatchGraph<TitanGraph> loader = new BatchGraph<TitanGraph>(g, BatchGraph.IdType.NUMBER, batchSize);
             loader.setEdgeIdKey(null);
             loader.setVertexIdKey("pid");
             Scanner data = new Scanner(new File(dataFile));
@@ -90,7 +93,6 @@ public class TitanBenchmark {
             watch.stop();
             System.out.println("Query 1 (ms): " + watch.getTime());
 
-
             watch.reset();watch.start();
             System.out.println("Size Q2: "+v.query().labels("follows").direction(Direction.OUT).count());
             watch.stop();
@@ -101,5 +103,5 @@ public class TitanBenchmark {
         }
 
     }
-        
+
 }

--- a/src/test/java/com/thinkaurelius/titan/TitanTestBed.java
+++ b/src/test/java/com/thinkaurelius/titan/TitanTestBed.java
@@ -1,11 +1,8 @@
 package com.thinkaurelius.titan;
 
-import com.google.common.collect.ImmutableList;
 import com.thinkaurelius.titan.core.*;
 import org.apache.commons.configuration.BaseConfiguration;
-import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.HierarchicalConfiguration;
 
 /**
  * (c) Matthias Broecheler (me@matthiasb.com)
@@ -18,8 +15,9 @@ public class TitanTestBed {
 
         int i = 5;
         Integer ii = i;
+        @SuppressWarnings("unused")
         Long ll = Long.valueOf(ii);
-        
+
         Configuration conf = new BaseConfiguration();
         conf.setProperty("storage.backend","hbase");
         //conf.setProperty("storage.hostname","127.0.0.1");

--- a/src/test/java/com/thinkaurelius/titan/blueprints/TitanBenchmarkSuite.java
+++ b/src/test/java/com/thinkaurelius/titan/blueprints/TitanBenchmarkSuite.java
@@ -1,8 +1,5 @@
 package com.thinkaurelius.titan.blueprints;
 
-import com.thinkaurelius.titan.core.*;
-import com.thinkaurelius.titan.core.TitanEdge;
-import com.thinkaurelius.titan.core.TitanVertex;
 import com.tinkerpop.blueprints.*;
 import com.tinkerpop.blueprints.impls.GraphTest;
 import com.tinkerpop.blueprints.util.io.graphml.GraphMLReader;

--- a/src/test/java/com/thinkaurelius/titan/blueprints/TransactionalTitanGraphTestSuite.java
+++ b/src/test/java/com/thinkaurelius/titan/blueprints/TransactionalTitanGraphTestSuite.java
@@ -3,9 +3,6 @@ package com.thinkaurelius.titan.blueprints;
 import com.tinkerpop.blueprints.*;
 import com.tinkerpop.blueprints.impls.GraphTest;
 
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
  * (c) Matthias Broecheler (me@matthiasb.com)
  */

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java
@@ -1,8 +1,6 @@
 package com.thinkaurelius.titan.diskstorage;
 
 
-import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.diskstorage.util.KeyValueStorageManagerAdapter;
 import com.thinkaurelius.titan.testutil.RandomGenerator;
 import org.junit.After;
 import org.junit.Assert;

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/MultiWriteKeyColumnValueStoreTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/MultiWriteKeyColumnValueStoreTest.java
@@ -6,14 +6,11 @@ import static org.junit.Assert.assertNull;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxKeyColumnValueTest.java
@@ -4,7 +4,6 @@ import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.KeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxLockKeyColumnValueStoreTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxLockKeyColumnValueStoreTest.java
@@ -7,7 +7,6 @@ import com.thinkaurelius.titan.diskstorage.LockKeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraThriftStorageManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class ExternalAstyanaxLockKeyColumnValueStoreTest extends LockKeyColumnValueStoreTest {
 	

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxMultiWriteKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/ExternalAstyanaxMultiWriteKeyColumnValueTest.java
@@ -3,7 +3,6 @@ package com.thinkaurelius.titan.diskstorage.astyanax;
 import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.MultiWriteKeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class ExternalAstyanaxMultiWriteKeyColumnValueTest extends MultiWriteKeyColumnValueStoreTest {
 

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxKeyColumnValueTest.java
@@ -6,7 +6,6 @@ import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.KeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraDaemonWrapper;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class InternalAstyanaxKeyColumnValueTest extends KeyColumnValueStoreTest {
 

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxLockKeyColumnValueStoreTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxLockKeyColumnValueStoreTest.java
@@ -7,10 +7,8 @@ import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.LockKeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraDaemonWrapper;
-import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraThriftStorageManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class InternalAstyanaxLockKeyColumnValueStoreTest extends LockKeyColumnValueStoreTest {
 	

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxMultiWriteKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxMultiWriteKeyColumnValueTest.java
@@ -6,7 +6,6 @@ import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.MultiWriteKeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraDaemonWrapper;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class InternalAstyanaxMultiWriteKeyColumnValueTest extends MultiWriteKeyColumnValueStoreTest {
 

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyDBjeKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyDBjeKeyColumnValueTest.java
@@ -7,8 +7,6 @@ import com.thinkaurelius.titan.diskstorage.berkeleydb.je.BerkeleyJEStorageManage
 import com.thinkaurelius.titan.diskstorage.util.KeyValueStorageManagerAdapter;
 import org.apache.commons.configuration.Configuration;
 
-import static junit.framework.Assert.assertEquals;
-
 
 public class BerkeleyDBjeKeyColumnValueTest extends KeyColumnValueStoreTest {
 

--- a/src/test/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -47,7 +47,7 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
         log.debug("Memory after: {}",memoryAfter/1024);
         //assertTrue(memoryAfter<100*1024*1024);
     }
-    
+
     @Test
     public void testBasic() {
         TitanKey weight = makeWeightPropertyKey("weight");
@@ -63,7 +63,8 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
         n1 = tx.getVertex(nid);
 
         for (TitanProperty prop : n1.getProperties()) {
-        	Object o = prop.getAttribute();
+            @SuppressWarnings("unused")
+            Object o = prop.getAttribute();
         }
         n1.query().relations();
         System.out.println();
@@ -88,17 +89,19 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
 
         TitanKey weight = tx.makeType().name("weight").functional().dataType(Double.class).makePropertyKey();
 
+        @SuppressWarnings("unused")
         TitanKey someid = tx.makeType().name("someid").functional().dataType(Object.class).indexed().makePropertyKey();
 
         TitanKey number = tx.makeType().name("number").dataType(Number.class).functional().makePropertyKey();
 
+        @SuppressWarnings("unused")
         TitanKey sint = tx.makeType().name("int").dataType(SpecialInt.class).functional().makePropertyKey();
 
         TitanLabel link = tx.makeType().name("link").simple().unidirected().makeEdgeLabel();
 
         TitanLabel connect = tx.makeType().name("connect").undirected().primaryKey(id).signature(weight).
                 functional(false).makeEdgeLabel();
-        
+
         TitanVertex v1 = tx.addVertex();
         v1.setProperty("uid","v1");
         v1.setProperty("someid",100l);
@@ -109,7 +112,7 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
         v1.setProperty("int",new SpecialInt(77));
 
         clopen();
-                
+
         id = tx.getPropertyKey("uid");
         assertEquals(TypeGroup.DEFAULT_GROUP,id.getGroup());
         assertTrue(id.isUnique());
@@ -237,6 +240,7 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
 		
 		n3 = tx.getVertex(nid);
 		assertEquals(353,n3.getProperty("uid"));
+        @SuppressWarnings("unused")
         TitanEdge e2 = n3.addEdge("knows",tx.addVertex());
 	}
 	
@@ -287,7 +291,8 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
 		}
 		
 	}
-	
+
+    @SuppressWarnings("unused")
 	@Test
 	public void testTypeGroup() {
 		TypeGroup g1 = TypeGroup.of(3, "group1");
@@ -474,8 +479,9 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
         TitanLabel connect = tx.makeType().name("connect").primaryKey(time).makeEdgeLabel();
         TitanLabel friend = tx.makeType().name("friend").primaryKey(time,weight).signature(author).makeEdgeLabel();
         TitanLabel knows = tx.makeType().name("knows").primaryKey(author,weight).makeEdgeLabel();
+        @SuppressWarnings("unused")
         TitanLabel follows = tx.makeType().name("follows").makeEdgeLabel();
-        
+
         int noVertices = 100;
         TitanVertex[] vs = new TitanVertex[noVertices];
         for (int i=0;i<noVertices;i++) {

--- a/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphPerformanceTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphPerformanceTest.java
@@ -1,9 +1,7 @@
 package com.thinkaurelius.titan.graphdb.astyanax;
 
 import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.diskstorage.astyanax.AstyanaxStorageManager;
 import com.thinkaurelius.titan.graphdb.TitanGraphPerformanceTest;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class ExternalAstyanaxGraphPerformanceTest extends TitanGraphPerformanceTest {
 	

--- a/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphTest.java
@@ -1,9 +1,7 @@
 package com.thinkaurelius.titan.graphdb.astyanax;
 
 import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.diskstorage.astyanax.AstyanaxStorageManager;
 import com.thinkaurelius.titan.graphdb.TitanGraphTest;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class ExternalAstyanaxGraphTest extends TitanGraphTest {
 

--- a/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/InternalAstyanaxGraphTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/InternalAstyanaxGraphTest.java
@@ -3,10 +3,8 @@ package com.thinkaurelius.titan.graphdb.astyanax;
 import org.junit.BeforeClass;
 
 import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.diskstorage.astyanax.AstyanaxStorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraDaemonWrapper;
 import com.thinkaurelius.titan.graphdb.TitanGraphTest;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
 
 public class InternalAstyanaxGraphTest extends TitanGraphTest {
 

--- a/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManagementTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManagementTest.java
@@ -85,6 +85,7 @@ public class IDManagementTest {
 			long id;
 			long groupID = RandomGenerator.randomLong(1, eid.getMaxGroupID());
             long partitionID = RandomGenerator.randomLong(1, eid.getMaxPartitionID());
+            @SuppressWarnings("unused")
 			boolean isProperty=false;
 			if (Math.random()<0.5) {
 				id = eid.getRelationshipTypeID(RandomGenerator.randomLong(1, eid.getMaxEdgeTypeID()),

--- a/src/test/java/com/thinkaurelius/titan/graphdb/serializer/ByteBufferTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/serializer/ByteBufferTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.*;
 
 public class ByteBufferTest {
 
+    @SuppressWarnings("unused")
 	private Logger log = LoggerFactory.getLogger(ByteBufferTest.class);
 	
 	@Before

--- a/src/test/java/com/thinkaurelius/titan/graphdb/serializer/KryoTest.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/serializer/KryoTest.java
@@ -81,6 +81,7 @@ public class KryoTest {
         ByteBuffer b = ByteBuffer.allocate(100);
         kryo.writeObjectData(b, E.E1);
         b.rewind();
+        @SuppressWarnings("unused")
         E instance = kryo.readObjectData(b, E.class);
     }
 

--- a/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SpecialInt.java
+++ b/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SpecialInt.java
@@ -8,7 +8,9 @@ import java.io.Serializable;
 
 public class SpecialInt implements Serializable {
 
-    private int value;
+	private static final long serialVersionUID = -3140817057952829487L;
+
+	private int value;
 
     public SpecialInt(int value) {
         this.value=value;

--- a/src/test/java/com/thinkaurelius/titan/testutil/ObjectSizer.java
+++ b/src/test/java/com/thinkaurelius/titan/testutil/ObjectSizer.java
@@ -24,34 +24,35 @@ public final class ObjectSizer {
 	public static Factory emptyConcurrentHashMap = new Factory() {
 		@Override
 		public Object newInstance() {
-			return fill(new ConcurrentHashMap(5,0.75f,2),20); 
+			return fill(new ConcurrentHashMap<Integer,Integer>(5,0.75f,2),20); 
 		}
 	};
 	
 	public static Factory emptyHashMap = new Factory() {
 		@Override
-		public Object newInstance() { return fill(new HashMap(10,0.75f),8); }
+		public Object newInstance() { return fill(new HashMap<Integer,Integer>(10,0.75f),8); }
 	};
 
 	public static Factory emptyConcurrentSkipListMap = new Factory() {
 		@Override
-		public Object newInstance() { return fill(new ConcurrentSkipListMap(),20); }
+		public Object newInstance() { return fill(new ConcurrentSkipListMap<Integer,Integer>(),20); }
 	};
 	
 	public static Factory emptyArrayList = new Factory() {
 		@Override
-		public Object newInstance() { return fill(new ArrayList(5),8); }
+		public Object newInstance() { return fill(new ArrayList<Integer>(5),8); }
 	};
 	
 	public static Factory emptyArrayQueue = new Factory() {
 		@Override
-		public Object newInstance() { return fill(new ArrayBlockingQueue(10),20); }
+		public Object newInstance() { return fill(new ArrayBlockingQueue<Integer>(10),20); }
 	};
 	
 	public static Factory emptyMultimap = new Factory() {
 		@Override
-		public Object newInstance() { 
-			return fill(HashMultimap.create(5,1),5); 
+		public Object newInstance() {
+			HashMultimap<Integer,Integer> map = HashMultimap.create(5,1);
+			return fill(map,5); 
 		}
 	};
 	
@@ -62,7 +63,7 @@ public final class ObjectSizer {
 	
 	public static Factory emptyCopyArrayList = new Factory() {
 		@Override
-		public Object newInstance() { return fill(new CopyOnWriteArrayList(),20); }
+		public Object newInstance() { return fill(new CopyOnWriteArrayList<Integer>(),20); }
 	};
 	
 	public static Factory emptyIntIntMap = new Factory() {
@@ -76,17 +77,17 @@ public final class ObjectSizer {
 	};
 	
 	
-	public static Map fill(Map m, int size) {
+	public static Map<Integer,Integer> fill(Map<Integer,Integer> m, int size) {
 		for (int i=0;i<size;i++) m.put(i, i);
 		return m;
 	}
 	
-	public static HashMultimap fill(HashMultimap m, int size) {
+	public static HashMultimap<Integer,Integer> fill(HashMultimap<Integer,Integer> m, int size) {
 		for (int i=0;i<size;i++) m.put(i, i);
 		return m;
 	}
 	
-	public static Collection fill(Collection m, int size) {
+	public static Collection<Integer> fill(Collection<Integer> m, int size) {
 		for (int i=0;i<size;i++) m.add(i);
 		return m;
 	}
@@ -124,6 +125,7 @@ public final class ObjectSizer {
     MemoryAssess mem = new MemoryAssess();
     //build a bunch of identical objects
     try {
+      @SuppressWarnings("unused")
       Object throwAway = factory.newInstance();
 
       mem.start();
@@ -141,11 +143,10 @@ public final class ObjectSizer {
 
   // PRIVATE //
   private static int fSAMPLE_SIZE = 100;
-  
-  
-  
+
   private static long fSLEEP_INTERVAL = 100;
 
+  @SuppressWarnings("unused")
   private static long getMemoryUse(){
     putOutTheGarbage();
     long totalMemory = Runtime.getRuntime().totalMemory();
@@ -164,9 +165,9 @@ public final class ObjectSizer {
   private static void collectGarbage() {
     try {
       System.gc();
-      Thread.currentThread().sleep(fSLEEP_INTERVAL);
+      Thread.sleep(fSLEEP_INTERVAL);
       System.runFinalization();
-      Thread.currentThread().sleep(fSLEEP_INTERVAL);
+      Thread.sleep(fSLEEP_INTERVAL);
     }
     catch (InterruptedException ex){
       ex.printStackTrace();

--- a/src/test/java/com/thinkaurelius/titan/tinkerpop/rexster/TitanGraphConfigurationTest.java
+++ b/src/test/java/com/thinkaurelius/titan/tinkerpop/rexster/TitanGraphConfigurationTest.java
@@ -1,20 +1,12 @@
 package com.thinkaurelius.titan.tinkerpop.rexster;
 
-import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.core.TitanGraph;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.tinkerpop.rexster.Tokens;
-import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.XMLConfiguration;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.FileInputStream;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Matthias Broecheler (http://www.matthiasb.com)
@@ -35,7 +27,8 @@ public class TitanGraphConfigurationTest {
         assertEquals(storage.getString(GraphDatabaseConfiguration.STORAGE_DIRECTORY_KEY), "home");
         assertEquals(storage.getString(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY), "local");
     }
-    
+
+    @SuppressWarnings("unused")
     private static final String subProperty(String key) {
         return Tokens.REXSTER_GRAPH_PROPERTIES + "." + key;
     }


### PR DESCRIPTION
This change cleans up all warnings in Eclipse and adds Eclipse code formatter settings.

The settings reflect what look like the general code style for the project, which are Eclipse defaults with the following settings:
- Spaces not tabs, indent size of 4
- 120 line width for both code and comments

I noticed a lot of mixed tab/space formatting and whitespace, so this config should probably be tweaked to reflect a agreed upon standard and all files formatted to deal with any issues, they make merges a pain.

Pity m2e can't import this automatically:

https://issues.sonatype.org/browse/MNGECLIPSE-2240
