### PR TITLE
Minor improvements to the build configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -10,6 +10,9 @@
     <artifactId>titan</artifactId>
     <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <prerequisites>
+        <maven>2.2.1</maven>
+    </prerequisites>
     <name>Titan: A Highly Scalable, Distributed Graph Database</name>
     <url>http://thinkaurelius.github.com/titan/</url>
     <description>
@@ -161,7 +164,8 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase</artifactId>
-            <!-- Update the hadoop-core artifact version when you update this -->
+            <!-- Update the hadoop-core artifact version when you update
+                this -->
             <version>0.92.1</version>
             <exclusions>
                 <exclusion>
@@ -229,13 +233,10 @@
                                 <exclude>**/Internal*.java</exclude>
                                 <exclude>**/*Suite.java</exclude>
                             </excludes>
-                            <!-- Forking per class is required for the
-                        Internal and External Cassandra tests
-                        to run in the same suite.  Otherwise,
-                        when an Internal runs before an External,
-                        the Internal Cassandra daemon will hold
-                        all its ports open and the External
-                        Cassandra daemon will fail to bind them.  -->
+                            <!-- Forking per class is required for the Internal
+                                and External Cassandra tests to run in the same suite. Otherwise, when an
+                                Internal runs before an External, the Internal Cassandra daemon will hold
+                                all its ports open and the External Cassandra daemon will fail to bind them. -->
                             <forkMode>always</forkMode>
                         </configuration>
                     </plugin>
@@ -263,24 +264,24 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
                     <excludes>
-                        <!-- Here go compile excluded src directories or files -->
+                        <!-- Here go compile excluded src directories or
+                            files -->
                     </excludes>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
                 <configuration>
                     <argLine>-Xms256m -Xmx756m</argLine>
                     <excludes>
                         <exclude>**/External*.java</exclude>
 
-                        <!-- Excluded because these take too long to run and require a lot of memory - see comprehensive profile -->
+                        <!-- Excluded because these take too long to run
+                            and require a lot of memory - see comprehensive profile -->
                         <exclude>**/*PerformanceTest.java</exclude>
                         <exclude>**/*ConcurrentTest.java</exclude>
                     </excludes>
@@ -288,7 +289,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -314,7 +314,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.5</version>
                 <executions>
                     <execution>
                         <id>copy-resources-127.0.0.1</id>
@@ -338,9 +337,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -356,9 +353,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -369,5 +364,58 @@
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.12.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.3.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>1.3.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,19 @@
                     </excludePackageNames>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cassandra.dir>${project.build.directory}/cassandra-tmp/workdir</cassandra.dir>
+        <titan.testdir>${project.build.directory}/titan-test</titan.testdir>
     </properties>
 
     <repositories>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,14 @@
+# A1 is set to be a FileAppender.
+log4j.appender.A1=org.apache.log4j.FileAppender
+log4j.appender.A1.File=target/test.log
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# Set root logger level to the designated level and its only appender to A1.
+log4j.rootLogger=DEBUG, A1
+
+log4j.logger.org.apache.cassandra=INFO
+log4j.logger.org.apache.hadoop=INFO
+log4j.logger.org.apache.zookeeper=INFO


### PR DESCRIPTION
Some minor improvements to the Maven configuration:
- Explicitly set plugin versions to prevent upgrades causing build failures
- Add prerequisite Maven version
- Set test directory to the build directory so 'clean' will take care of the database files
- Improve readability of test output by sending logging events to a file
- Attach sources
