### PR TITLE
Reentrant write lock leak in SimpleTypeManager

### DIFF
--- a/src/main/java/com/thinkaurelius/titan/graphdb/types/manager/SimpleTypeManager.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/types/manager/SimpleTypeManager.java
@@ -17,163 +17,173 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.thinkaurelius.titan.graphdb.types.manager.TypeManagerUtil.convertSignature;
 
-
 public class SimpleTypeManager implements TypeManager {
 
-	private final InternalTitanGraph graphdb;
-	private final TypeFactory factory;
-	
-	private final ReadWriteLock mapLock;
-	private final Lock mapReadLock;
-	private final Lock mapWriteLock;
-	
-	private final Map<Long,TypeInformation> idIndex;
-	private final Map<String,Long> nameIndex;
-	
-	public SimpleTypeManager(InternalTitanGraph graphdb) {
-		this.graphdb = graphdb;
-		idIndex = new HashMap<Long,TypeInformation>();
-		nameIndex = new HashMap<String,Long>();
-		
-		factory = new StandardTypeFactory();
-		
-		mapLock = new ReentrantReadWriteLock();
-		mapReadLock = mapLock.readLock();
-		mapWriteLock = mapLock.writeLock();
-	}
-	
-	
-	
-	public void close() {
-		idIndex.clear();
-		nameIndex.clear();
-	}
+    private final InternalTitanGraph graphdb;
+    private final TypeFactory factory;
 
-	@Override
-	public boolean containsType(long id, InternalTitanTransaction tx) {
-		mapReadLock.lock();
-		boolean contains = idIndex.containsKey(Long.valueOf(id));
-		mapReadLock.unlock();
-		if (contains) return true;
-		else return graphdb.containsVertexID(id, tx);
-	}
+    private final ReadWriteLock mapLock;
+    private final Lock mapReadLock;
+    private final Lock mapWriteLock;
 
+    private final Map<Long, TypeInformation> idIndex;
+    private final Map<String, Long> nameIndex;
 
+    public SimpleTypeManager(InternalTitanGraph graphdb) {
+        this.graphdb = graphdb;
+        idIndex = new HashMap<Long, TypeInformation>();
+        nameIndex = new HashMap<String, Long>();
 
-	@Override
-	public boolean containsType(String name, InternalTitanTransaction tx) {
-		mapReadLock.lock();
-		boolean contains = nameIndex.containsKey(name);
-		mapReadLock.unlock();
-		if (contains) return true;
-		else return graphdb.indexRetrieval(name, SystemKey.TypeName, tx).length>0;
-	}
+        factory = new StandardTypeFactory();
 
-	@Override
-	public void committed(InternalTitanType type) {
-		Long id = type.getID();
-		mapWriteLock.lock();
-		if (nameIndex.containsKey(type.getName()))
-			throw new InvalidElementException("TitanRelation Type with name does already exist: " + type.getName() + " | " + type.isEdgeLabel(), type);
-		nameIndex.put(type.getName(),id);
-		//Determine system edge ids
-		long nameEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.TypeName).getID();
-		long defEdgeID = -1;
-		if (type.isPropertyKey()) {
-			defEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.PropertyTypeDefinition).getID();
-		} else {
-			assert type.isEdgeLabel();
-			defEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.RelationshipTypeDefinition).getID();
-		}
-		idIndex.put(id, new TypeInformation(type.getDefinition(), defEdgeID, nameEdgeID ));
-		mapWriteLock.unlock();
-	}
+        mapLock = new ReentrantReadWriteLock();
+        mapReadLock = mapLock.readLock();
+        mapWriteLock = mapLock.writeLock();
+    }
 
-	private void checkUniqueName(String name) {
-		mapReadLock.lock();
-		boolean exists = nameIndex.containsKey(name);
-		mapReadLock.unlock();
-		if (exists)
-			throw new IllegalArgumentException("TitanRelation Type with name does already exist: " + name);
-	}
-	
-	@Override
-	public TitanKey createPropertyKey(InternalTitanTransaction tx, String name,
-                                      TypeCategory category, Directionality directionality,
-                                      TypeVisibility visibility,
-                                      FunctionalType isfunctional, TitanType[] keysig, TitanType[] compactsig,
-                                      TypeGroup group,
-                                      boolean isKey, boolean hasIndex, Class<?> objectType) {
-		checkUniqueName(name);
-		StandardPropertyKey pt = new StandardPropertyKey(name,category,directionality,visibility,
-				isfunctional,convertSignature(keysig),convertSignature(compactsig),group,isKey,hasIndex,objectType);
-		return factory.createNewPropertyKey(pt, tx);
-	}
+    public void close() {
+        idIndex.clear();
+        nameIndex.clear();
+    }
 
+    @Override
+    public boolean containsType(long id, InternalTitanTransaction tx) {
+        boolean contains = false;
+        mapReadLock.lock();
+        try {
+            contains = idIndex.containsKey(Long.valueOf(id));
+        } finally {
+            mapReadLock.unlock();
+        }
+        return contains ? true : graphdb.containsVertexID(id, tx);
+    }
 
-	@Override
-	public TitanLabel createEdgeLabel(InternalTitanTransaction tx, String name,
-                                      TypeCategory category, Directionality directionality,
-                                      TypeVisibility visibility,
-                                      FunctionalType isfunctional, TitanType[] keysig, TitanType[] compactsig,
-                                      TypeGroup group) {
-		checkUniqueName(name);
-		StandardEdgeLabel rt = new StandardEdgeLabel(name,category,directionality,visibility,
-				isfunctional,convertSignature(keysig),convertSignature(compactsig),group);
-		return factory.createNewEdgeLabel(rt, tx);
-	}
+    @Override
+    public boolean containsType(String name, InternalTitanTransaction tx) {
+        boolean contains = false;
+        mapReadLock.lock();
+        try {
+            contains = nameIndex.containsKey(name);
+        } finally {
+            mapReadLock.unlock();
+        }
+        return contains ? true : graphdb.indexRetrieval(name, SystemKey.TypeName, tx).length > 0;
+    }
 
-
-
-	@Override
-	public InternalTitanType getType(long id, InternalTitanTransaction tx) {
-		mapReadLock.lock();
-		TypeInformation info = idIndex.get(Long.valueOf(id));
-		mapReadLock.unlock();
-		if (info==null) {
-			if (!tx.containsVertex(id)) throw new IllegalArgumentException("TitanType is unknown: " + id);
-			IDInspector idspec = graphdb.getIDInspector();
-			assert idspec.isEdgeTypeID(id);
-			InternalTitanType et=null;
-			if (idspec.isPropertyTypeID(id)) {
-				et = factory.createExistingPropertyKey(id, tx);
-			} else if (idspec.isRelationshipTypeID(id)) {
-				et = factory.createExistingEdgeLabel(id, tx);
-			} else throw new AssertionError("Unexpected type id: " + id);
-			mapWriteLock.lock();
-            if (idIndex.containsKey(Long.valueOf(id))) et = getType(id, tx);
-            else committed(et);
+    @Override
+    public void committed(InternalTitanType type) {
+        Long id = type.getID();
+        mapWriteLock.lock();
+        try {
+            if (nameIndex.containsKey(type.getName()))
+                throw new InvalidElementException("TitanRelation Type with name does already exist: " + type.getName()
+                        + " | " + type.isEdgeLabel(), type);
+            nameIndex.put(type.getName(), id);
+            // Determine system edge ids
+            long nameEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.TypeName).getID();
+            long defEdgeID = -1;
+            if (type.isPropertyKey()) {
+                defEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.PropertyTypeDefinition).getID();
+            } else {
+                assert type.isEdgeLabel();
+                defEdgeID = QueryUtil.queryHiddenFunctionalProperty(type, SystemKey.RelationshipTypeDefinition).getID();
+            }
+            idIndex.put(id, new TypeInformation(type.getDefinition(), defEdgeID, nameEdgeID));
+        } finally {
             mapWriteLock.unlock();
-			return et;
-		} else {
-			return factory.createExistingType(id, info, tx);
-		}
-	}
+        }
+    }
 
+    private void checkUniqueName(String name) {
+        mapReadLock.lock();
+        try {
+            if (nameIndex.containsKey(name))
+                throw new IllegalArgumentException("TitanRelation Type with name does already exist: " + name);
+        } finally {
+            mapReadLock.unlock();
+        }
+    }
 
+    @Override
+    public TitanKey createPropertyKey(InternalTitanTransaction tx, String name, TypeCategory category,
+            Directionality directionality, TypeVisibility visibility, FunctionalType isfunctional, TitanType[] keysig,
+            TitanType[] compactsig, TypeGroup group, boolean isKey, boolean hasIndex, Class<?> objectType) {
+        checkUniqueName(name);
+        StandardPropertyKey pt = new StandardPropertyKey(name, category, directionality, visibility, isfunctional,
+                convertSignature(keysig), convertSignature(compactsig), group, isKey, hasIndex, objectType);
+        return factory.createNewPropertyKey(pt, tx);
+    }
 
-	@Override
-	public InternalTitanType getType(String name, InternalTitanTransaction tx) {
-		mapReadLock.lock();
-		Long id = nameIndex.get(name);
-		mapReadLock.unlock();
-		if (id==null) {
-			long[] ids = graphdb.indexRetrieval(name, SystemKey.TypeName, tx);
-			if (ids.length==0) return null;
-			else {
-				assert ids.length==1;
-				id = ids[0];
-			}
-		} 
-		return getType(id, tx);
-	}
+    @Override
+    public TitanLabel createEdgeLabel(InternalTitanTransaction tx, String name, TypeCategory category,
+            Directionality directionality, TypeVisibility visibility, FunctionalType isfunctional, TitanType[] keysig,
+            TitanType[] compactsig, TypeGroup group) {
+        checkUniqueName(name);
+        StandardEdgeLabel rt = new StandardEdgeLabel(name, category, directionality, visibility, isfunctional,
+                convertSignature(keysig), convertSignature(compactsig), group);
+        return factory.createNewEdgeLabel(rt, tx);
+    }
 
+    @Override
+    public InternalTitanType getType(long id, InternalTitanTransaction tx) {
+        TypeInformation info = null;
+        mapReadLock.lock();
+        try {
+            info = idIndex.get(Long.valueOf(id));
+        } finally {
+            mapReadLock.unlock();
+        }
+        if (info == null) {
+            if (!tx.containsVertex(id))
+                throw new IllegalArgumentException("TitanType is unknown: " + id);
+            IDInspector idspec = graphdb.getIDInspector();
+            assert idspec.isEdgeTypeID(id);
+            InternalTitanType et = null;
+            if (idspec.isPropertyTypeID(id)) {
+                et = factory.createExistingPropertyKey(id, tx);
+            } else if (idspec.isRelationshipTypeID(id)) {
+                et = factory.createExistingEdgeLabel(id, tx);
+            } else
+                throw new AssertionError("Unexpected type id: " + id);
+            mapWriteLock.lock();
+            try {
+                if (idIndex.containsKey(Long.valueOf(id)))
+                    et = getType(id, tx);
+                else
+                    committed(et);
+            } finally {
+                mapWriteLock.unlock();
+            }
+            return et;
+        } else {
+            return factory.createExistingType(id, info, tx);
+        }
+    }
 
+    @Override
+    public InternalTitanType getType(String name, InternalTitanTransaction tx) {
+        Long id = null;
+        mapReadLock.lock();
+        try {
+            id = nameIndex.get(name);
+        } finally {
+            mapReadLock.unlock();
+        }
+        if (id == null) {
+            long[] ids = graphdb.indexRetrieval(name, SystemKey.TypeName, tx);
+            if (ids.length == 0)
+                return null;
+            else {
+                assert ids.length == 1;
+                id = ids[0];
+            }
+        }
+        return getType(id, tx);
+    }
 
-	@Override
-	public TypeMaker getTypeMaker(InternalTitanTransaction tx) {
-		return new StandardTypeMaker(tx,this);
-	}
+    @Override
+    public TypeMaker getTypeMaker(InternalTitanTransaction tx) {
+        return new StandardTypeMaker(tx, this);
+    }
 
-	
 }


### PR DESCRIPTION
If a concurrent operation creates a type and the STM throws this exception, it leaks the map write lock causing all other type operations to stall:

```
[error] application - Unexpected error
com.thinkaurelius.titan.core.InvalidElementException: TitanRelation Type with name does already exist: start | false
    at com.thinkaurelius.titan.graphdb.types.manager.SimpleTypeManager.committed(SimpleTypeManager.java:77) ~[titan-0.1-SNAPSHOT.jar:na]
    at com.thinkaurelius.titan.graphdb.database.StandardTitanGraph.commitEdgeTypes(StandardTitanGraph.java:650) ~[titan-0.1-SNAPSHOT.jar:na]
    at com.thinkaurelius.titan.graphdb.database.StandardTitanGraph.save(StandardTitanGraph.java:638) ~[titan-0.1-SNAPSHOT.jar:na]
    at com.thinkaurelius.titan.graphdb.transaction.StandardPersistTitanTx.commit(StandardPersistTitanTx.java:167) ~[titan-0.1-SNAPSHOT.jar:na]
    at com.thinkaurelius.titan.graphdb.blueprints.TitanBlueprintsTransaction.stopTransaction(TitanBlueprintsTransaction.java:25) ~[titan-0.1-SNAPSHOT.jar:na]
    at com.thinkaurelius.titan.graphdb.blueprints.TitanBlueprintsGraph.stopTransaction(TitanBlueprintsGraph.java:37) ~[titan-0.1-SNAPSHOT.jar:na]
```

This adds try/finally locks around all blocks betwen the lock/unlock requests.
