### PR TITLE
Vertexes with unique key properties aren't returned by getVertices

### DIFF
--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
@@ -467,8 +467,9 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
                 vertices.addAll(attrSubindex.get(attribute));
             }
             Map<Object, TitanVertex> keySubindex = keyIndex.get(key);
-            if (keySubindex != null) {
-                vertices.add(keySubindex.get(attribute));
+            TitanVertex vertex = keySubindex.get(attribute);
+            if (keySubindex != null && vertex != null) {
+                vertices.add(vertex);
             }
             return vertices;
         } else {

--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.thinkaurelius.titan.core.*;
-import com.thinkaurelius.titan.core.InvalidElementException;
 import com.thinkaurelius.titan.graphdb.blueprints.TitanBlueprintsTransaction;
 import com.thinkaurelius.titan.graphdb.database.InternalTitanGraph;
 import com.thinkaurelius.titan.graphdb.query.ComplexTitanQuery;
@@ -455,15 +454,21 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
         Preconditions.checkNotNull(key);
         attribute = AttributeUtil.prepareAttribute(attribute,key.getDataType());
         if (key.hasIndex()) {
-            //First, get stuff from disk
+            // First, get stuff from disk
             long[] nodeids = getVertexIDsFromDisk(key, attribute);
             Set<TitanVertex> vertices = new HashSet<TitanVertex>(nodeids.length);
-            for (int i=0;i<nodeids.length;i++)
+            for (int i = 0; i < nodeids.length; i++) {
                 vertices.add(getExistingVertex(nodeids[i]));
-            //Next, the in-memory stuff
-            Multimap<Object,TitanVertex> subindex = attributeIndex.get(key);
-            if (subindex!=null) {
-                vertices.addAll(subindex.get(attribute));
+            }
+
+            // Next, the in-memory stuff
+            Multimap<Object, TitanVertex> attrSubindex = attributeIndex.get(key);
+            if (attrSubindex != null) {
+                vertices.addAll(attrSubindex.get(attribute));
+            }
+            Map<Object, TitanVertex> keySubindex = keyIndex.get(key);
+            if (keySubindex != null) {
+                vertices.add(keySubindex.get(attribute));
             }
             return vertices;
         } else {

--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
@@ -467,9 +467,11 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
                 vertices.addAll(attrSubindex.get(attribute));
             }
             Map<Object, TitanVertex> keySubindex = keyIndex.get(key);
-            TitanVertex vertex = keySubindex.get(attribute);
-            if (keySubindex != null && vertex != null) {
-                vertices.add(vertex);
+            if (keySubindex != null) {
+                TitanVertex vertex = keySubindex.get(attribute);
+                if (vertex != null) {
+                    vertices.add(vertex);
+                }
             }
             return vertices;
         } else {


### PR DESCRIPTION
Oversight in this method - keyIndex isn't checked, though if the transaction is committed, they'll be retrieved from disk successfully.
