### PR TITLE
AbstractTitanTx null ambiguity cleanup

### DIFF
--- a/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/transaction/AbstractTitanTx.java
@@ -36,107 +36,106 @@ import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class AbstractTitanTx extends TitanBlueprintsTransaction implements InternalTitanTransaction {
 
-	private static final Logger log = LoggerFactory.getLogger(AbstractTitanTx.class);
-    
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(AbstractTitanTx.class);
+
     private static final Set<InternalTitanVertex> NO_NODES = ImmutableSet.of();
 
     protected InternalTitanGraph graphdb;
 
-	protected final TypeManager etManager;
-	protected final VertexFactory vertexFactory;
-	protected final RelationFactory edgeFactory;
-	
-	private ConcurrentMap<TitanKey,ConcurrentMap<Object,TitanVertex>> keyIndex;
-    private final Lock keyedPropertyCreateLock;
-    private ConcurrentMap<TitanKey,Multimap<Object,TitanVertex>> attributeIndex;
+    protected final TypeManager etManager;
+    protected final VertexFactory vertexFactory;
+    protected final RelationFactory edgeFactory;
 
+    private ConcurrentMap<TitanKey, ConcurrentMap<Object, TitanVertex>> keyIndex;
+    private final Lock keyedPropertyCreateLock;
+    private ConcurrentMap<TitanKey, Multimap<Object, TitanVertex>> attributeIndex;
 
     private Set<InternalTitanVertex> newNodes;
     private VertexCache vertexCache;
 
     private boolean isOpen;
-	private final TransactionConfig config;
+    private final TransactionConfig config;
 
-	public AbstractTitanTx(InternalTitanGraph g, VertexFactory vertexFac, RelationFactory edgeFac,
-                           TypeManager etManage, TransactionConfig config) {
-		graphdb = g;
+    public AbstractTitanTx(InternalTitanGraph g, VertexFactory vertexFac, RelationFactory edgeFac,
+            TypeManager etManage, TransactionConfig config) {
+        graphdb = g;
         etManager = etManage;
-		vertexFactory = vertexFac;
-		edgeFactory = edgeFac;
-		edgeFactory.setTransaction(this);
-		
+        vertexFactory = vertexFac;
+        edgeFactory = edgeFac;
+        edgeFactory.setTransaction(this);
 
-		this.config=config;
-		isOpen = true;
+        this.config = config;
+        isOpen = true;
 
-		if (!config.isReadOnly()) { //TODO: don't maintain newNodes for batch loading transactions
-            newNodes = Collections.newSetFromMap(new ConcurrentHashMap<InternalTitanVertex,Boolean>(10,0.75f,2));
+        if (!config.isReadOnly()) { // TODO: don't maintain newNodes for batch loading transactions
+            newNodes = Collections.newSetFromMap(new ConcurrentHashMap<InternalTitanVertex, Boolean>(10, 0.75f, 2));
         } else {
-            newNodes= NO_NODES;
+            newNodes = NO_NODES;
         }
         vertexCache = new StandardVertexCache();
 
-		keyIndex = new ConcurrentHashMap<TitanKey,ConcurrentMap<Object,TitanVertex>>(20,0.75f,2);
-        attributeIndex = new ConcurrentHashMap<TitanKey,Multimap<Object,TitanVertex>>(20,0.75f,2);
+        keyIndex = new ConcurrentHashMap<TitanKey, ConcurrentMap<Object, TitanVertex>>(20, 0.75f, 2);
+        attributeIndex = new ConcurrentHashMap<TitanKey, Multimap<Object, TitanVertex>>(20, 0.75f, 2);
         keyedPropertyCreateLock = new ReentrantLock();
-	}
-
-
-	protected final void verifyWriteAccess() {
-		if (config.isReadOnly()) throw new UnsupportedOperationException("Cannot create new entities in read-only transaction");
-        verifyOpen();
-	}
-    
-    protected final void verifyOpen() {
-        if (isClosed()) throw GraphDatabaseException.transactionNotOpenException();
     }
-	
-	/* ---------------------------------------------------------------
-	 * TitanVertex and TitanRelation creation
-	 * ---------------------------------------------------------------
-	 */
-	
+
+    protected final void verifyWriteAccess() {
+        if (config.isReadOnly())
+            throw new UnsupportedOperationException("Cannot create new entities in read-only transaction");
+        verifyOpen();
+    }
+
+    protected final void verifyOpen() {
+        if (isClosed())
+            throw GraphDatabaseException.transactionNotOpenException();
+    }
+
+    /*
+     * ------------------------------------ TitanVertex and TitanRelation creation ------------------------------------
+     */
+
     @Override
     public void registerNewEntity(InternalTitanVertex n) {
-        assert (!(n instanceof InternalRelation) || !((InternalRelation)n).isInline());
+        assert (!(n instanceof InternalRelation) || !((InternalRelation) n).isInline());
         assert n.isNew();
         assert !n.hasID();
 
         boolean isNode = !(n instanceof InternalRelation);
         if (config.assignIDsImmediately()) {
-            graphdb.assignID(n);           
-            if (isNode) vertexCache.add(n,n.getID());
-        } else if (newNodes!= NO_NODES) {
+            graphdb.assignID(n);
+            if (isNode)
+                vertexCache.add(n, n.getID());
+        } else if (newNodes != NO_NODES) {
             if (isNode) {
                 newNodes.add(n);
             }
         }
     }
 
-
-	@Override
-	public TitanVertex addVertex() {
-		verifyWriteAccess();
-		InternalTitanVertex n = vertexFactory.createNew(this);
-		return n;
-	}
-    
+    @Override
+    public TitanVertex addVertex() {
+        verifyWriteAccess();
+        InternalTitanVertex n = vertexFactory.createNew(this);
+        return n;
+    }
 
     @Override
     public boolean containsVertex(long id) {
         verifyOpen();
-        if (vertexCache.contains(id)) return true;
-        else return false;
+        if (vertexCache.contains(id))
+            return true;
+        else
+            return false;
     }
 
     @Override
     public TitanVertex getVertex(long id) {
         verifyOpen();
-        if (getTxConfiguration().doVerifyNodeExistence() &&
-                !containsVertex(id)) return null;
+        if (getTxConfiguration().doVerifyNodeExistence() && !containsVertex(id))
+            return null;
         return getExistingVertex(id);
     }
-
 
     @Override
     public InternalTitanVertex getExistingVertex(long id) {
@@ -144,9 +143,9 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
     }
 
     private InternalTitanVertex getExisting(long id) {
-        synchronized(vertexCache) {
+        synchronized (vertexCache) {
             InternalTitanVertex node = vertexCache.get(id);
-            if (node==null) {
+            if (node == null) {
                 IDInspector idspec = graphdb.getIDInspector();
 
                 if (idspec.isEdgeTypeID(id)) {
@@ -154,15 +153,16 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
                 } else if (graphdb.isReferenceVertexID(id)) {
                     throw new UnsupportedOperationException("Reference vertices are currently not supported");
                 } else if (idspec.isNodeID(id)) {
-                    node = vertexFactory.createExisting(this,id);
-                } else throw new IllegalArgumentException("ID could not be recognized");
+                    node = vertexFactory.createExisting(this, id);
+                } else
+                    throw new IllegalArgumentException("ID could not be recognized");
                 vertexCache.add(node, id);
             }
             return node;
         }
 
     }
-    
+
     @Override
     public void deleteVertex(InternalTitanVertex n) {
         verifyWriteAccess();
@@ -170,8 +170,10 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
         if (n.hasID()) {
             removed = vertexCache.remove(n.getID());
         } else {
-            if (newNodes!=NO_NODES) removed = newNodes.remove(n);
-            else removed=true;
+            if (newNodes != NO_NODES)
+                removed = newNodes.remove(n);
+            else
+                removed = true;
         }
         assert removed;
     }
@@ -181,7 +183,8 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
         verifyWriteAccess();
         // Check that attribute of keyed propertyType is unique and lock if so
         boolean isUniqueKey = key.isUnique();
-        if (isUniqueKey) keyedPropertyCreateLock.lock();
+        if (isUniqueKey)
+            keyedPropertyCreateLock.lock();
         InternalRelation e = null;
         try {
             if (isUniqueKey && config.doVerifyKeyUniqueness() && getVertex(key, attribute) != null) {
@@ -191,249 +194,246 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
             e = edgeFactory.createNewProperty(key, (InternalTitanVertex) vertex, attribute);
             addedRelation(e);
         } finally {
-            if (isUniqueKey) keyedPropertyCreateLock.unlock();
+            if (isUniqueKey)
+                keyedPropertyCreateLock.unlock();
         }
-        assert(e != null);
+        assert (e != null);
         return (TitanProperty) e;
     }
 
-	@Override
-	public TitanProperty addProperty(TitanVertex vertex, String key, Object attribute) {
-		return addProperty(vertex, getPropertyKey(key), attribute);
-	}
+    @Override
+    public TitanProperty addProperty(TitanVertex vertex, String key, Object attribute) {
+        return addProperty(vertex, getPropertyKey(key), attribute);
+    }
 
+    @Override
+    public TitanEdge addEdge(TitanVertex outVertex, TitanVertex inVertex, TitanLabel label) {
+        verifyWriteAccess();
+        InternalRelation e = edgeFactory.createNewRelationship(label, (InternalTitanVertex) outVertex,
+                (InternalTitanVertex) inVertex);
+        addedRelation(e);
+        return (TitanEdge) e;
+    }
 
-	@Override
-	public TitanEdge addEdge(TitanVertex outVertex, TitanVertex inVertex, TitanLabel label) {
-		verifyWriteAccess();
-        InternalRelation e = edgeFactory.createNewRelationship(label, (InternalTitanVertex)outVertex, (InternalTitanVertex)inVertex);
-		addedRelation(e);
-		return (TitanEdge)e;
-	}
+    @Override
+    public TitanEdge addEdge(TitanVertex outVertex, TitanVertex inVertex, String label) {
+        return addEdge(outVertex, inVertex, getEdgeLabel(label));
+    }
 
+    @Override
+    public TypeMaker makeType() {
+        verifyWriteAccess();
+        return etManager.getTypeMaker(this);
+    }
 
-	@Override
-	public TitanEdge addEdge(TitanVertex outVertex, TitanVertex inVertex, String label) {
-		return addEdge(outVertex, inVertex, getEdgeLabel(label));
-	}
-	
-
-	@Override
-	public TypeMaker makeType() {
-		verifyWriteAccess();
-		return etManager.getTypeMaker(this);
-	}
-
-	@Override
-	public boolean containsType(String name) {
+    @Override
+    public boolean containsType(String name) {
         verifyOpen();
-		Map<Object,TitanVertex> subindex = keyIndex.get(SystemKey.TypeName);
-		if (subindex==null || !subindex.containsKey(name)) {
+        Map<Object, TitanVertex> subindex = keyIndex.get(SystemKey.TypeName);
+        if (subindex == null || !subindex.containsKey(name)) {
             return etManager.containsType(name, this);
-        } else return true;
-	}
+        } else
+            return true;
+    }
 
     @Override
     public TitanType getType(String name) {
         verifyOpen();
-        Map<Object,TitanVertex> subindex = keyIndex.get(SystemKey.TypeName);
+        Map<Object, TitanVertex> subindex = keyIndex.get(SystemKey.TypeName);
         TitanType et = null;
-        if (subindex!=null) {
-            et = (TitanType)subindex.get(name);
+        if (subindex != null) {
+            et = (TitanType) subindex.get(name);
         }
-        if (et==null) {
-            //Second, check TypeManager
+        if (et == null) {
+            // Second, check TypeManager
             InternalTitanType eti = etManager.getType(name, this);
-            if (eti!=null)
+            if (eti != null)
                 vertexCache.add(eti, eti.getID());
-            et=eti;
+            et = eti;
         }
         return et;
     }
 
-	@Override
-	public TitanKey getPropertyKey(String name) {
-		TitanType et = getType(name);
-		if (et==null) {
+    @Override
+    public TitanKey getPropertyKey(String name) {
+        TitanType et = getType(name);
+        if (et == null) {
             return config.getAutoEdgeTypeMaker().makeKey(name, makeType());
         } else if (et.isPropertyKey()) {
-			return (TitanKey)et;
-		} else throw new IllegalArgumentException("The type of given name is not a key: " + name);
+            return (TitanKey) et;
+        } else
+            throw new IllegalArgumentException("The type of given name is not a key: " + name);
 
-	}
-	
+    }
 
-	@Override
-	public TitanLabel getEdgeLabel(String name) {
-		TitanType et = getType(name);
-		if (et==null) {
+    @Override
+    public TitanLabel getEdgeLabel(String name) {
+        TitanType et = getType(name);
+        if (et == null) {
             return config.getAutoEdgeTypeMaker().makeLabel(name, makeType());
         } else if (et.isEdgeLabel()) {
-			return (TitanLabel)et;
-		} else throw new IllegalArgumentException("The type of given name is not a label: " + name);
-	}
-	
+            return (TitanLabel) et;
+        } else
+            throw new IllegalArgumentException("The type of given name is not a label: " + name);
+    }
 
-	@Override
-	public void addedRelation(InternalRelation relation) {
-		verifyWriteAccess();
-		Preconditions.checkArgument(relation.isNew());
-	}
-	
-	@Override
-	public void deletedRelation(InternalRelation relation) {
-		verifyWriteAccess();
-		if (relation.isProperty() && !relation.isRemoved() && !relation.isInline()) {
-			TitanProperty prop = (TitanProperty) relation;
-			if (prop.getPropertyKey().hasIndex()) {
-				removeKeyFromIndex(prop);
-			}
-		}
-	}
-	
-	
-	@Override
-	public void loadedRelation(InternalRelation relation) {
-		if (relation.isProperty() && !relation.isInline()) {
-			TitanProperty prop = (TitanProperty) relation;
+    @Override
+    public void addedRelation(InternalRelation relation) {
+        verifyWriteAccess();
+        Preconditions.checkArgument(relation.isNew());
+    }
+
+    @Override
+    public void deletedRelation(InternalRelation relation) {
+        verifyWriteAccess();
+        if (relation.isProperty() && !relation.isRemoved() && !relation.isInline()) {
+            TitanProperty prop = (TitanProperty) relation;
             if (prop.getPropertyKey().hasIndex()) {
-			    addProperty2Index(prop);
+                removeKeyFromIndex(prop);
             }
-		}
-	}
-	
-	@Override
-	public InternalTitanQuery query(InternalTitanVertex n) {
-		return new ComplexTitanQuery(n);
-	}
+        }
+    }
 
-	@Override
-	public TitanQuery query(long nodeid) {
-		return new ComplexTitanQuery((InternalTitanVertex) getVertex(nodeid));
-	}
+    @Override
+    public void loadedRelation(InternalRelation relation) {
+        if (relation.isProperty() && !relation.isInline()) {
+            TitanProperty prop = (TitanProperty) relation;
+            if (prop.getPropertyKey().hasIndex()) {
+                addProperty2Index(prop);
+            }
+        }
+    }
 
-	@Override
-	public Iterable<Vertex> getVertices() {
+    @Override
+    public InternalTitanQuery query(InternalTitanVertex n) {
+        return new ComplexTitanQuery(n);
+    }
+
+    @Override
+    public TitanQuery query(long nodeid) {
+        return new ComplexTitanQuery((InternalTitanVertex) getVertex(nodeid));
+    }
+
+    @Override
+    public Iterable<Vertex> getVertices() {
         throw new UnsupportedOperationException("Titan does not support global vertex operations - use Faunus instead");
-	}
+    }
 
-
-	@Override
-	public Iterable<Edge> getEdges() {
+    @Override
+    public Iterable<Edge> getEdges() {
         throw new UnsupportedOperationException("Titan does not support global edge operations - use Faunus instead");
-	}
+    }
 
-	
-	/* ---------------------------------------------------------------
-	 * Index Handling
-	 * ---------------------------------------------------------------
-	 */	
-	
-	private void addProperty2Index(TitanProperty property) {
-	    addProperty2Index(property.getPropertyKey(), property.getAttribute(), property.getVertex());
-	}
+    /*
+     * ----------------------------------------------- Index Handling ----------------------------------------------
+     */
 
-	private static Factory<ConcurrentMap<Object,TitanVertex>> keyIndexFactory = new Factory<ConcurrentMap<Object,TitanVertex>>() {
-		@Override
-		public ConcurrentMap<Object, TitanVertex> create() {
-			return new ConcurrentHashMap<Object,TitanVertex>(10,0.75f,4);
-		}
-	};
+    private void addProperty2Index(TitanProperty property) {
+        addProperty2Index(property.getPropertyKey(), property.getAttribute(), property.getVertex());
+    }
 
-    private static Factory<Multimap<Object,TitanVertex>> attributeIndexFactory = new Factory<Multimap<Object,TitanVertex>>() {
+    private static Factory<ConcurrentMap<Object, TitanVertex>> keyIndexFactory = new Factory<ConcurrentMap<Object, TitanVertex>>() {
         @Override
-        public Multimap<Object, TitanVertex> create() {
-            Multimap<Object,TitanVertex> map = ArrayListMultimap.create(10,20);
-            return map;
-            //return Multimaps.synchronizedSetMultimap(map);
+        public ConcurrentMap<Object, TitanVertex> create() {
+            return new ConcurrentHashMap<Object, TitanVertex>(10, 0.75f, 4);
         }
     };
-	
-	protected void addProperty2Index(TitanKey key, Object att, TitanVertex vertex) {
+
+    private static Factory<Multimap<Object, TitanVertex>> attributeIndexFactory = new Factory<Multimap<Object, TitanVertex>>() {
+        @Override
+        public Multimap<Object, TitanVertex> create() {
+            Multimap<Object, TitanVertex> map = ArrayListMultimap.create(10, 20);
+            return map;
+            // return Multimaps.synchronizedSetMultimap(map);
+        }
+    };
+
+    protected void addProperty2Index(TitanKey key, Object att, TitanVertex vertex) {
         Preconditions.checkArgument(key.hasIndex());
-		if (key.isUnique()) {
-            //TODO ignore NO-ENTRTY
-            ConcurrentMap<Object,TitanVertex> subindex = Maps.putIfAbsent(keyIndex, key, keyIndexFactory);
+        if (key.isUnique()) {
+            // TODO ignore NO-ENTRTY
+            ConcurrentMap<Object, TitanVertex> subindex = Maps.putIfAbsent(keyIndex, key, keyIndexFactory);
 
             TitanVertex oth = subindex.putIfAbsent(att, vertex);
-            if (oth!=null && !oth.equals(vertex)) {
+            if (oth != null && !oth.equals(vertex)) {
                 throw new IllegalArgumentException("The value is already used by another vertex and the key is unique");
             }
         } else {
-            Multimap<Object,TitanVertex> subindex = Maps.putIfAbsent(attributeIndex, key, attributeIndexFactory);
-            subindex.put(att,vertex);
+            Multimap<Object, TitanVertex> subindex = Maps.putIfAbsent(attributeIndex, key, attributeIndexFactory);
+            subindex.put(att, vertex);
         }
-	}
-	
-	private void removeKeyFromIndex(TitanProperty property) {
+    }
+
+    private void removeKeyFromIndex(TitanProperty property) {
         Preconditions.checkArgument(property.getPropertyKey().hasIndex());
-        
-		TitanKey type = property.getPropertyKey();
-		if (type.isUnique()) {
-            Map<Object,TitanVertex> subindex = keyIndex.get(type);
+
+        TitanKey type = property.getPropertyKey();
+        if (type.isUnique()) {
+            Map<Object, TitanVertex> subindex = keyIndex.get(type);
             Preconditions.checkNotNull(subindex);
             TitanVertex n = subindex.remove(property.getAttribute());
-            assert n!=null && n.equals(property.getVertex());
-            //TODO Set to NO-ENTRY node object
+            assert n != null && n.equals(property.getVertex());
+            // TODO Set to NO-ENTRY node object
         } else {
             boolean hasIdenticalProperty = false;
             for (TitanProperty p2 : property.getVertex().getProperties(type)) {
                 if (!p2.equals(property) && p2.getAttribute().equals(property.getAttribute())) {
-                    hasIdenticalProperty=true;
+                    hasIdenticalProperty = true;
                     break;
                 }
             }
             if (!hasIdenticalProperty) {
-                Multimap<Object,TitanVertex> subindex = attributeIndex.get(type);
+                Multimap<Object, TitanVertex> subindex = attributeIndex.get(type);
                 Preconditions.checkNotNull(subindex);
-                boolean removed = subindex.remove(property.getAttribute(),property.getVertex());
+                boolean removed = subindex.remove(property.getAttribute(), property.getVertex());
                 assert removed;
             }
         }
 
-	}
+    }
 
     // #### Keyed Properties #####
 
-	@Override
-	public TitanVertex getVertex(TitanKey key, Object value) {
+    @Override
+    public TitanVertex getVertex(TitanKey key, Object value) {
         verifyOpen();
         Preconditions.checkNotNull(key);
-		Preconditions.checkArgument(key.isUnique(),"Key is not declared unique");
-        value = AttributeUtil.prepareAttribute(value,key.getDataType());
-		Map<Object,TitanVertex> subindex = keyIndex.get(key);
-		if (subindex==null) {
-			return null;
-		} else {
-            //TODO: check for NO-ENTRY and return null
-			return subindex.get(value);
-		}
-	}
-	
-	@Override
-	public TitanVertex getVertex(String type, Object value) {
-        if (!containsType(type)) return null;
-		return getVertex(getPropertyKey(type), value);
-	}
+        Preconditions.checkArgument(key.isUnique(), "Key is not declared unique");
+        value = AttributeUtil.prepareAttribute(value, key.getDataType());
+        Map<Object, TitanVertex> subindex = keyIndex.get(key);
+        if (subindex == null) {
+            return null;
+        } else {
+            // TODO: check for NO-ENTRY and return null
+            return subindex.get(value);
+        }
+    }
+
+    @Override
+    public TitanVertex getVertex(String type, Object value) {
+        if (!containsType(type))
+            return null;
+        return getVertex(getPropertyKey(type), value);
+    }
 
     // #### General Indexed Properties #####
 
-	@Override
-	public Iterable<Vertex> getVertices(String key, Object attribute) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public Iterable<Vertex> getVertices(String key, Object attribute) {
         Preconditions.checkNotNull(key);
-        if (!containsType(key)) return ImmutableSet.of();
+        if (!containsType(key))
+            return ImmutableSet.of();
         TitanKey tkey = getPropertyKey(key);
-        return (Iterable)getVertices(tkey, attribute);
-        //return new PropertyFilteredIterable<Vertex>(key,attribute,getVertices());
-	}
-	
+        return (Iterable) getVertices(tkey, attribute);
+        // return new PropertyFilteredIterable<Vertex>(key,attribute,getVertices());
+    }
 
-	
-	@Override
-	public Iterable<TitanVertex> getVertices(final TitanKey key, Object attribute) {
+    @Override
+    public Iterable<TitanVertex> getVertices(final TitanKey key, Object attribute) {
         verifyOpen();
         Preconditions.checkNotNull(key);
-        attribute = AttributeUtil.prepareAttribute(attribute,key.getDataType());
+        attribute = AttributeUtil.prepareAttribute(attribute, key.getDataType());
         if (key.hasIndex()) {
             // First, get stuff from disk
             long[] nodeids = getVertexIDsFromDisk(key, attribute);
@@ -456,72 +456,57 @@ public abstract class AbstractTitanTx extends TitanBlueprintsTransaction impleme
             }
             return vertices;
         } else {
-            throw new UnsupportedOperationException("getVertices only supports indexed keys since Titan does not support global vertex operations");
+            throw new UnsupportedOperationException(
+                    "getVertices only supports indexed keys since Titan does not support global vertex operations");
         }
-	}
+    }
 
-	
-	/* ---------------------------------------------------------------
-	 * Transaction Handling
-	 * ---------------------------------------------------------------
-	 */	
-	
-	private void close() {
-        vertexCache.close(); vertexCache =null;
-		keyIndex.clear(); keyIndex=null;
-		isOpen=false;
-	}
+    /*
+     * --------------------------------------------------------------- Transaction Handling
+     * ---------------------------------------------------------------
+     */
 
-	
-	@Override
-	public synchronized void commit() {
-		close();
-	}
+    private void close() {
+        vertexCache.close();
+        vertexCache = null;
+        keyIndex.clear();
+        keyIndex = null;
+        isOpen = false;
+    }
 
-	@Override
-	public synchronized void abort() {
-		close();
-	}
-	
-	
-	@Override
-	public RelationFactory getRelationFactory() {
-		return edgeFactory;
-	}
-	
-	@Override
-	public boolean isOpen() {
-		return isOpen;
-	}
-	
-	@Override
-	public boolean isClosed() {
-		return !isOpen;
-	}
-	
-	@Override
-	public TransactionConfig getTxConfiguration() {
-		return config;
-	}
+    @Override
+    public synchronized void commit() {
+        close();
+    }
 
-	@Override
-	public boolean hasModifications() {
-		return !config.isReadOnly() && !newNodes.isEmpty();
-	}
+    @Override
+    public synchronized void abort() {
+        close();
+    }
 
+    @Override
+    public RelationFactory getRelationFactory() {
+        return edgeFactory;
+    }
 
+    @Override
+    public boolean isOpen() {
+        return isOpen;
+    }
 
+    @Override
+    public boolean isClosed() {
+        return !isOpen;
+    }
 
+    @Override
+    public TransactionConfig getTxConfiguration() {
+        return config;
+    }
 
+    @Override
+    public boolean hasModifications() {
+        return !config.isReadOnly() && !newNodes.isEmpty();
+    }
 
-
-
-
-
-
-
-
-
-
-	
 }


### PR DESCRIPTION
I ran into NPEs when I fixed a bug in this class due to some null ambiguity issues. This pull requests removes the use of null where it's not part of a contracted method return:
- Use Guava Optional for newNodes
- Collection.get\* == null has two possible meanings - the key doesn't exist or the key has a null value, use contains\* instead (maybe consider null adverse collections which don't allow nulls in keys or values)
- Set a few fields to final and removed unneeded null dereferencing on close - clear() is called on those collections anyway
