### PR TITLE
Cleaned up several classes as part of a coding standards discussion

### DIFF
--- a/src/main/java/com/thinkaurelius/titan/core/TitanGraph.java
+++ b/src/main/java/com/thinkaurelius/titan/core/TitanGraph.java
@@ -51,6 +51,4 @@ public interface TitanGraph extends Graph, KeyIndexableGraph, ThreadedTransactio
      * @see #shutdown()
      */
     public boolean isOpen();
-
-	
 }

--- a/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraDaemonWrapper.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraDaemonWrapper.java
@@ -20,8 +20,7 @@ public class CassandraDaemonWrapper {
 	
 	public static synchronized void start(String cassandraYamlPath) {
 		if (started) {
-			if (null != cassandraYamlPath &&
-					!cassandraYamlPath.equals(liveCassandraYamlPath)) {
+			if (null != cassandraYamlPath && !cassandraYamlPath.equals(liveCassandraYamlPath)) {
 				log.warn("Can't start in-process Cassandra instance " +
 						"with yaml path {} because an instance was " +
 						"previously started with yaml path {}", 
@@ -30,7 +29,7 @@ public class CassandraDaemonWrapper {
 			
 			return;
 		}
-		
+
 		log.debug("Current working directory: {}", System.getProperty("user.dir"));
 		
 		System.setProperty("cassandra.config", cassandraYamlPath);
@@ -39,7 +38,7 @@ public class CassandraDaemonWrapper {
 		(new Thread(new CassandraRunner())).run();
 		
 		liveCassandraYamlPath = cassandraYamlPath;
-		
+
 		started = true;
 	}
 	

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/AdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/AdjacencyList.java
@@ -6,26 +6,25 @@ import com.thinkaurelius.titan.graphdb.relations.InternalRelation;
 import com.thinkaurelius.titan.util.datastructures.IterablesUtil;
 
 public interface AdjacencyList extends Iterable<InternalRelation> {
-	
-	public static final Iterable<InternalRelation> Empty = IterablesUtil.emptyIterable();
-	
-	public AdjacencyList addEdge(InternalRelation e, ModificationStatus status);
-	
-	public AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status);
-	
-	public void removeEdge(InternalRelation e, ModificationStatus status);
 
-	public boolean isEmpty();
-	
-	public boolean containsEdge(InternalRelation e);
-	
-	public Iterable<InternalRelation> getEdges();
+    public static final Iterable<InternalRelation> Empty = IterablesUtil.emptyIterable();
 
-	public Iterable<InternalRelation> getEdges(TitanType type);
+    public AdjacencyList addEdge(InternalRelation e, ModificationStatus status);
 
-	public Iterable<InternalRelation> getEdges(TypeGroup group);
-	
-	
-	public AdjacencyListFactory getFactory();
-	
+    public AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status);
+
+    public void removeEdge(InternalRelation e, ModificationStatus status);
+
+    public boolean isEmpty();
+
+    public boolean containsEdge(InternalRelation e);
+
+    public Iterable<InternalRelation> getEdges();
+
+    public Iterable<InternalRelation> getEdges(TitanType type);
+
+    public Iterable<InternalRelation> getEdges(TypeGroup group);
+
+    public AdjacencyListFactory getFactory();
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjListFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjListFactory.java
@@ -4,57 +4,58 @@ import com.thinkaurelius.titan.graphdb.relations.InternalRelation;
 
 public class ArrayAdjListFactory implements AdjacencyListFactory {
 
-	private enum Extension { Typed, UniformSet };
-	
-	private static final float defaultUpdateFactor = 2.0f;
-	private static final int defaultInitialCapacity=5;
-	private static final int defaultMaxCapacity=20;
-	
-	private final int initialCapacity;
-	private final int maxCapacity;
-	private final float updateFactor;
-	private final Extension extension;
-	
-	public static final ArrayAdjListFactory defaultInstance = new ArrayAdjListFactory(Extension.Typed);
-	public static final ArrayAdjListFactory uniformSetInstance = new ArrayAdjListFactory(Extension.UniformSet);
-	
-	private ArrayAdjListFactory(Extension ext) {
-		initialCapacity=defaultInitialCapacity;
-		maxCapacity=defaultMaxCapacity;
-		updateFactor = defaultUpdateFactor;
-		extension = ext;
-	}
-	
-	@Override
-	public AdjacencyList emptyList() {
-		return new ArrayAdjacencyList(this);
-	}
+    private enum Extension {Typed, UniformSet}
 
-	@Override
-	public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
-		AdjacencyList newadj = null;
-		switch(extension) {
-		case Typed: 
-			newadj = new TypedAdjacencyList(TypedAdjListFactory.defaultInstance,list);
-			break;
-		case UniformSet:
-			newadj = new SetAdjacencyList(SetAdjListFactory.uniformTypeInstance,list);
-			break;
-		default: throw new IllegalArgumentException("Unexpected input: " +extension);
-		}
-		newadj.addEdge(newEdge,status);
-		return newadj;
-	}
-	
-	int getInitialCapacity() {
-		return initialCapacity;
-	}
+    private static final float defaultUpdateFactor = 2.0f;
+    private static final int defaultInitialCapacity = 5;
+    private static final int defaultMaxCapacity = 20;
 
-	int getMaxCapacity() {
-		return maxCapacity;
-	}
-	
-	int updateCapacity(int oldCapacity) {
-		return (int)Math.round(oldCapacity*updateFactor);
-	}
+    private final int initialCapacity;
+    private final int maxCapacity;
+    private final float updateFactor;
+    private final Extension extension;
+
+    public static final ArrayAdjListFactory defaultInstance = new ArrayAdjListFactory(Extension.Typed);
+    public static final ArrayAdjListFactory uniformSetInstance = new ArrayAdjListFactory(Extension.UniformSet);
+
+    private ArrayAdjListFactory(Extension ext) {
+        initialCapacity = defaultInitialCapacity;
+        maxCapacity = defaultMaxCapacity;
+        updateFactor = defaultUpdateFactor;
+        extension = ext;
+    }
+
+    @Override
+    public AdjacencyList emptyList() {
+        return new ArrayAdjacencyList(this);
+    }
+
+    @Override
+    public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
+        AdjacencyList newadj;
+        switch (extension) {
+            case Typed:
+                newadj = new TypedAdjacencyList(TypedAdjListFactory.defaultInstance, list);
+                break;
+            case UniformSet:
+                newadj = new SetAdjacencyList(SetAdjListFactory.uniformTypeInstance, list);
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected input: " + extension);
+        }
+        newadj.addEdge(newEdge, status);
+        return newadj;
+    }
+
+    int getInitialCapacity() {
+        return initialCapacity;
+    }
+
+    int getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    int updateCapacity(int oldCapacity) {
+        return Math.round(oldCapacity * updateFactor);
+    }
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ArrayAdjacencyList.java
@@ -11,226 +11,214 @@ import java.util.NoSuchElementException;
 
 public class ArrayAdjacencyList implements AdjacencyList {
 
-	private static final long serialVersionUID = -2868708972683152295L;
+    private static final long serialVersionUID = -2868708972683152295L;
 
-	private final ArrayAdjListFactory factory;
-	private InternalRelation[] contents;
+    private final ArrayAdjListFactory factory;
+    private InternalRelation[] contents;
 
-	
-	ArrayAdjacencyList(ArrayAdjListFactory factory) {
-		this.factory=factory;
-		contents = new InternalRelation[factory.getInitialCapacity()];
-	}
-	
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
-		return addEdge(e,false,status);
-	}
+    ArrayAdjacencyList(ArrayAdjListFactory factory) {
+        this.factory = factory;
+        contents = new InternalRelation[factory.getInitialCapacity()];
+    }
 
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
+        return addEdge(e, false, status);
+    }
 
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
-		int emptySlot = -1;
-		for (int i=0;i<contents.length;i++) {
-			if (contents[i]==null) {
-				emptySlot=i;
-				continue;
-			}
-			InternalRelation oth = contents[i];
-			assert oth!=null;
-			if (oth.equals(e)) {
-				status.nochange();
-				return this;
-			} else if (checkTypeUniqueness && oth.getType().equals(e.getType())) {
-				throw new InvalidElementException("Cannot add functional edge since an edge of that type already exists",e);
-			}
-		}
-		if (emptySlot<0 && contents.length>=factory.getMaxCapacity()) {
-			return factory.extend(this, e, status);
-		} else {
-			//Add internally
-			if (emptySlot>=0) {
-				contents[emptySlot]=e;
-			} else {
-				//Expand & copy
-				InternalRelation[] contents2 = new InternalRelation[factory.updateCapacity(contents.length)];
-				System.arraycopy(contents, 0, contents2, 0, contents.length);
-				contents2[contents.length]=e;
-				contents=contents2;
-			}
-			status.change();
-			return this;
-		}
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
+        int emptySlot = -1;
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] == null) {
+                emptySlot = i;
+                continue;
+            }
+            InternalRelation oth = contents[i];
+            assert oth != null;
+            if (oth.equals(e)) {
+                status.nochange();
+                return this;
+            } else if (checkTypeUniqueness && oth.getType().equals(e.getType())) {
+                throw new InvalidElementException("Cannot add functional edge since an edge of that type already exists", e);
+            }
+        }
+        if (emptySlot < 0 && contents.length >= factory.getMaxCapacity()) {
+            return factory.extend(this, e, status);
+        }
 
-	@Override
-	public boolean containsEdge(InternalRelation e) {
-		for (int i=0;i<contents.length;i++) {
-			if (contents[i]!=null && e.equals(contents[i])) return true;
-		}
-		return false;
-	}
-	
+        //Add internally
+        if (emptySlot >= 0) {
+            contents[emptySlot] = e;
+        } else {
+            //Expand & copy
+            InternalRelation[] contents2 = new InternalRelation[factory.updateCapacity(contents.length)];
+            System.arraycopy(contents, 0, contents2, 0, contents.length);
+            contents2[contents.length] = e;
+            contents = contents2;
+        }
+        status.change();
+        return this;
+    }
 
-	@Override
-	public boolean isEmpty() {
-		for (int i=0;i<contents.length;i++) {
-			if (contents[i]!=null) return false;
-		}
-		return true;
-	}
+    @Override
+    public boolean containsEdge(InternalRelation e) {
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] != null && e.equals(contents[i])) return true;
+        }
+        return false;
+    }
 
-	@Override
-	public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
-		status.nochange();
-		for (int i=0;i<contents.length;i++) {
-			if (contents[i]!=null && e.equals(contents[i])) {
-				contents[i]=null;
-				status.change();
-			}
-		}
-	}
+    @Override
+    public boolean isEmpty() {
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] != null) return false;
+        }
+        return true;
+    }
 
-	@Override
-	public AdjacencyListFactory getFactory() {
-		return factory;
-	}
+    @Override
+    public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
+        status.nochange();
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] != null && e.equals(contents[i])) {
+                contents[i] = null;
+                status.change();
+            }
+        }
+    }
 
-	
-
-	@Override
-	public Iterable<InternalRelation> getEdges() {
-		return new Iterable<InternalRelation>() {
-
-			@Override
-			public Iterator<InternalRelation> iterator() {
-				return new InternalIterator();
-			}
-			
-		};
-	}
-
-	@Override
-	public Iterable<InternalRelation> getEdges(final TitanType type) {
-		return new Iterable<InternalRelation>() {
-
-			@Override
-			public Iterator<InternalRelation> iterator() {
-				return new InternalTypeIterator(type);
-			}
-			
-		};
-	}
-	
-
-	@Override
-	public Iterable<InternalRelation> getEdges(final TypeGroup group) {
-		return new Iterable<InternalRelation>() {
-
-			@Override
-			public Iterator<InternalRelation> iterator() {
-				return new InternalGroupIterator(group);
-			}
-			
-		};
-	}
-
-	
-	private class InternalGroupIterator extends InternalIterator {
-		
-		private final TypeGroup group;
-		
-		private InternalGroupIterator(TypeGroup group) {
-			super(false);
-			Preconditions.checkNotNull(group);
-			this.group=group;
-			findNext();
-		}
-		
-		@Override
-		protected boolean applies(InternalRelation edge) {
-			return group.equals(edge.getType().getGroup());
-		}
-		
-	}
-	
-	private class InternalTypeIterator extends InternalIterator {
-		
-		private final TitanType type;
-		
-		private InternalTypeIterator(TitanType type) {
-			super(false);
-			Preconditions.checkNotNull(type);
-			this.type=type;
-			findNext();
-		}
-		
-		@Override
-		protected boolean applies(InternalRelation edge) {
-			return type.equals(edge.getType());
-		}
-		
-	}
-	
-	private class InternalIterator implements Iterator<InternalRelation> {
-
-		private InternalRelation next = null;
-		private int position = -1;
-		private InternalRelation last = null;
-
-		
-		InternalIterator() {
-			this(true);
-		}
-		
-		InternalIterator(boolean initialize) {
-			if (initialize) findNext();
-		}
-		
-
-		
-		protected void findNext() {
-			last = next;
-			next = null;
-			for (position = position+1; position<contents.length;position++) {
-				if (contents[position]!=null && applies(contents[position])) {
-					next = contents[position];
-					break;
-				}
-			}
-		}
-		
-		protected boolean applies(InternalRelation edge) {
-			return true;
-		}
-		
-		@Override
-		public boolean hasNext() {
-			return next!=null;
-		}
-
-		@Override
-		public InternalRelation next() {
-			if (next==null) throw new NoSuchElementException();
-			InternalRelation old = next;
-			findNext();
-			return old;
-		}
-
-		@Override
-		public void remove() {
-			if (last==null) throw new NoSuchElementException();
-			removeEdge(last,ModificationStatus.none);
-		}
-		
-	}
+    @Override
+    public AdjacencyListFactory getFactory() {
+        return factory;
+    }
 
 
-	@Override
-	public Iterator<InternalRelation> iterator() {
-		return new InternalIterator();
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges() {
+        return new Iterable<InternalRelation>() {
 
+            @Override
+            public Iterator<InternalRelation> iterator() {
+                return new InternalIterator();
+            }
 
-	
+        };
+    }
+
+    @Override
+    public Iterable<InternalRelation> getEdges(final TitanType type) {
+        return new Iterable<InternalRelation>() {
+
+            @Override
+            public Iterator<InternalRelation> iterator() {
+                return new InternalTypeIterator(type);
+            }
+
+        };
+    }
+
+    @Override
+    public Iterable<InternalRelation> getEdges(final TypeGroup group) {
+        return new Iterable<InternalRelation>() {
+
+            @Override
+            public Iterator<InternalRelation> iterator() {
+                return new InternalGroupIterator(group);
+            }
+
+        };
+    }
+
+    @Override
+    public Iterator<InternalRelation> iterator() {
+        return new InternalIterator();
+    }
+
+    private class InternalGroupIterator extends InternalIterator {
+
+        private final TypeGroup group;
+
+        private InternalGroupIterator(TypeGroup group) {
+            super(false);
+            Preconditions.checkNotNull(group);
+            this.group = group;
+            findNext();
+        }
+
+        @Override
+        protected boolean applies(InternalRelation edge) {
+            return group.equals(edge.getType().getGroup());
+        }
+
+    }
+
+    private class InternalTypeIterator extends InternalIterator {
+
+        private final TitanType type;
+
+        private InternalTypeIterator(TitanType type) {
+            super(false);
+            Preconditions.checkNotNull(type);
+            this.type = type;
+            findNext();
+        }
+
+        @Override
+        protected boolean applies(InternalRelation edge) {
+            return type.equals(edge.getType());
+        }
+
+    }
+
+    private class InternalIterator implements Iterator<InternalRelation> {
+
+        private InternalRelation next = null;
+        private int position = -1;
+        private InternalRelation last = null;
+
+        InternalIterator() {
+            this(true);
+        }
+
+        InternalIterator(boolean initialize) {
+            if (initialize) findNext();
+        }
+
+        protected void findNext() {
+            last = next;
+            next = null;
+            for (position = position + 1; position < contents.length; position++) {
+                if (contents[position] != null && applies(contents[position])) {
+                    next = contents[position];
+                    break;
+                }
+            }
+        }
+
+        protected boolean applies(InternalRelation edge) {
+            return true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public InternalRelation next() {
+            if (next == null) throw new NoSuchElementException();
+            InternalRelation old = next;
+            findNext();
+            return old;
+        }
+
+        @Override
+        public void remove() {
+            if (last == null) throw new NoSuchElementException();
+            removeEdge(last, ModificationStatus.none);
+        }
+
+    }
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/InitialAdjListFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/InitialAdjListFactory.java
@@ -4,52 +4,45 @@ import com.thinkaurelius.titan.graphdb.relations.InternalRelation;
 
 public enum InitialAdjListFactory implements AdjacencyListFactory {
 
-	BasicFactory {
+    BasicFactory {
+        @Override
+        public AdjacencyList emptyList() {
+            return basicInitial;
+        }
 
-		@Override
-		public AdjacencyList emptyList() {
-			return basicInitial;
-		}
+        @Override
+        public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
+            AdjacencyList newList = new ArrayAdjacencyList(ArrayAdjListFactory.defaultInstance);
+            newList.addEdge(newEdge, status);
+            return newList;
+        }
+    },
 
+    EmptyFactory {
+        @Override
+        public AdjacencyList emptyList() {
+            return emptyInitial;
+        }
 
-		@Override
-		public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge,
-				ModificationStatus status) {
-			AdjacencyList newList = new ArrayAdjacencyList(ArrayAdjListFactory.defaultInstance);
-			newList.addEdge(newEdge,status);
-			return newList;
-		}
-	},
-	
-	EmptyFactory {
-		
-		@Override
-		public AdjacencyList emptyList() {
-			return emptyInitial;
-		}
+        @Override
+        public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
+            throw new IllegalStateException("Cannot add to emptied adjacency list");
+        }
 
+    };
 
-		@Override
-		public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge,
-				ModificationStatus status) {
-			throw new IllegalStateException("Cannot add to emptied adjacency list");
-		}
-		
-	};
-	
-	
-	private static final AdjacencyList basicInitial = new InitialAdjacencyList(BasicFactory);
+    private static final AdjacencyList basicInitial = new InitialAdjacencyList(BasicFactory);
 
-	private static final AdjacencyList emptyInitial = new InitialAdjacencyList(EmptyFactory);
+    private static final AdjacencyList emptyInitial = new InitialAdjacencyList(EmptyFactory);
 
-	/*
-	 * These two abstract declarations are a workaround for bug 6724345
-	 * which was fixed in JDK 7 b39:
-	 * 
-	 * http://bugs.sun.com/view_bug.do?bug_id=6724345
-	 */
-	public abstract AdjacencyList emptyList();
-	public abstract AdjacencyList extend(AdjacencyList list, 
-			InternalRelation newEdge, ModificationStatus status);
-	
+    /*
+      * These two abstract declarations are a workaround for bug 6724345
+      * which was fixed in JDK 7 b39:
+      *
+      * http://bugs.sun.com/view_bug.do?bug_id=6724345
+      */
+    public abstract AdjacencyList emptyList();
+
+    public abstract AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status);
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/InitialAdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/InitialAdjacencyList.java
@@ -10,62 +10,62 @@ import java.util.Iterator;
 
 public class InitialAdjacencyList implements AdjacencyList {
 
-	private static final Iterable<InternalRelation> Empty = IterablesUtil.emptyIterable();
-	
-	private final AdjacencyListFactory factory;
-	
-	InitialAdjacencyList(AdjacencyListFactory factory) {
-		this.factory=factory;
-	}
-	
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
-		return factory.extend(this, e, status);
-	}
+    private static final Iterable<InternalRelation> Empty = IterablesUtil.emptyIterable();
 
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
-		return factory.extend(this, e, status);
-	}
+    private final AdjacencyListFactory factory;
 
-	@Override
-	public boolean containsEdge(InternalRelation e) {
-		return false;
-	}
+    InitialAdjacencyList(AdjacencyListFactory factory) {
+        this.factory = factory;
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges() {
-		return Empty;
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
+        return factory.extend(this, e, status);
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges(TitanType type) {
-		return Empty;
-	}
-	
-	@Override
-	public Iterable<InternalRelation> getEdges(TypeGroup group) {
-		return Empty;
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
+        return factory.extend(this, e, status);
+    }
 
-	@Override
-	public void removeEdge(InternalRelation e, ModificationStatus status) {
-		status.nochange();
-	}
+    @Override
+    public boolean containsEdge(InternalRelation e) {
+        return false;
+    }
 
-	@Override
-	public AdjacencyListFactory getFactory() {
-		return factory;
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges() {
+        return Empty;
+    }
 
-	@Override
-	public Iterator<InternalRelation> iterator() {
-		return Iterators.emptyIterator();
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges(TitanType type) {
+        return Empty;
+    }
 
-	@Override
-	public boolean isEmpty() {
-		return true;
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges(TypeGroup group) {
+        return Empty;
+    }
+
+    @Override
+    public void removeEdge(InternalRelation e, ModificationStatus status) {
+        status.nochange();
+    }
+
+    @Override
+    public AdjacencyListFactory getFactory() {
+        return factory;
+    }
+
+    @Override
+    public Iterator<InternalRelation> iterator() {
+        return Iterators.emptyIterator();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
 
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ModificationStatus.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/ModificationStatus.java
@@ -2,37 +2,37 @@ package com.thinkaurelius.titan.graphdb.adjacencylist;
 
 public class ModificationStatus {
 
-	public static final ModificationStatus none = new ModificationStatus() {
-		@Override
-		public boolean hasChanged() {
-			throw new UnsupportedOperationException("Cannot query modification status");
-		}
-	};
-	
-	private boolean modified;
-	
-	public ModificationStatus() {
-		modified = false;
-	}
-	
-	void change() {
-		modified = true;
-	}
-	
-	void nochange() {
-		modified=false;
-	}
-	
-	void setModified(boolean mod) {
-		modified=mod;
-	}
-	
-	public boolean hasChanged() {
-		return modified;
-	}
-	
-	public void reset() {
-		modified = false;
-	}
-	
+    public static final ModificationStatus none = new ModificationStatus() {
+        @Override
+        public boolean hasChanged() {
+            throw new UnsupportedOperationException("Cannot query modification status");
+        }
+    };
+
+    private boolean modified;
+
+    public ModificationStatus() {
+        modified = false;
+    }
+
+    void change() {
+        modified = true;
+    }
+
+    void nochange() {
+        modified = false;
+    }
+
+    void setModified(boolean mod) {
+        modified = mod;
+    }
+
+    public boolean hasChanged() {
+        return modified;
+    }
+
+    public void reset() {
+        modified = false;
+    }
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/SetAdjListFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/SetAdjListFactory.java
@@ -4,42 +4,41 @@ import com.thinkaurelius.titan.graphdb.relations.InternalRelation;
 
 public class SetAdjListFactory implements AdjacencyListFactory {
 
-	private static final int expectedNumEdges = 50;
-	
-	public static final SetAdjListFactory defaultInstance = new SetAdjListFactory(false);
-	public static final SetAdjListFactory uniformTypeInstance = new SetAdjListFactory(true);
-	
-	private final boolean uniformType;
-	
-	private SetAdjListFactory(boolean uniformType) {
-		this.uniformType = uniformType;
-	}
-	
-	@Override
-	public AdjacencyList emptyList() {
-		return new SetAdjacencyList(this);
-	}
+    private static final int expectedNumEdges = 50;
 
-	@Override
-	public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge,
-			ModificationStatus status) {
-		throw new UnsupportedOperationException("There is no extension for set adjacency lists");
-	}
+    public static final SetAdjListFactory defaultInstance = new SetAdjListFactory(false);
+    public static final SetAdjListFactory uniformTypeInstance = new SetAdjListFactory(true);
 
-	boolean isUniformTyped() {
-		return uniformType;
-	}
-	
-	int getInitialCapacity() {
-		return expectedNumEdges;
-	}
-	
-	int getConcurrencyLevel() {
-		return 1;
-	}
-	
-	float getLoadFactor() {
-		return 0.75f;
-	}
+    private final boolean uniformType;
+
+    private SetAdjListFactory(boolean uniformType) {
+        this.uniformType = uniformType;
+    }
+
+    @Override
+    public AdjacencyList emptyList() {
+        return new SetAdjacencyList(this);
+    }
+
+    @Override
+    public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
+        throw new UnsupportedOperationException("There is no extension for set adjacency lists");
+    }
+
+    boolean isUniformTyped() {
+        return uniformType;
+    }
+
+    int getInitialCapacity() {
+        return expectedNumEdges;
+    }
+
+    int getConcurrencyLevel() {
+        return 1;
+    }
+
+    float getLoadFactor() {
+        return 0.75f;
+    }
 
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/SetAdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/SetAdjacencyList.java
@@ -14,102 +14,105 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class SetAdjacencyList implements AdjacencyList {
 
-	
-	private final SetAdjListFactory factory;
-	private Set<InternalRelation> content;
+    private final SetAdjListFactory factory;
+    private Set<InternalRelation> content;
 
-	SetAdjacencyList(SetAdjListFactory factory) {
-		this.factory = factory;
-		content = Collections.newSetFromMap(new ConcurrentHashMap<InternalRelation,Boolean>
-						(factory.getInitialCapacity(),factory.getLoadFactor(),factory.getConcurrencyLevel()));
-	}
-	
-	SetAdjacencyList(SetAdjListFactory factory, AdjacencyList base) {
-		this(factory);
-		for (InternalRelation e : base.getEdges()) {
-			addEdge(e,ModificationStatus.none);
-		}
-	}
-	
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
-		return addEdge(e,false,status);
-	}
+    SetAdjacencyList(SetAdjListFactory factory) {
+        this.factory = factory;
+        content = Collections.newSetFromMap(new ConcurrentHashMap<InternalRelation, Boolean>
+                (factory.getInitialCapacity(), factory.getLoadFactor(), factory.getConcurrencyLevel()));
+    }
 
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
-		if (checkTypeUniqueness) {
-			if (content.contains(e)) status.nochange();
-			else {
-				if ((factory.isUniformTyped() && !content.isEmpty()) ||
-						(!factory.isUniformTyped() && !Iterables.isEmpty(getEdges(e.getType())) )) {
-					throw new InvalidElementException("Cannot add functional edge since an edge of that type already exists",e);
-				} else {
-					status.change();
-					content.add(e);
-				}
-			}
-		} else {
-			status.setModified(content.add(e));
-		}
-		return this;
-	}
+    SetAdjacencyList(SetAdjListFactory factory, AdjacencyList base) {
+        this(factory);
+        for (InternalRelation e : base.getEdges()) {
+            addEdge(e, ModificationStatus.none);
+        }
+    }
 
-	@Override
-	public boolean containsEdge(InternalRelation e) {
-		return content.contains(e);
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
+        return addEdge(e, false, status);
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges() {
-		return content;
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
+        if (checkTypeUniqueness) {
+            if (content.contains(e)) status.nochange();
+            else {
+                if ((factory.isUniformTyped() && !content.isEmpty()) ||
+                        (!factory.isUniformTyped() && !Iterables.isEmpty(getEdges(e.getType())))) {
+                    throw new InvalidElementException("Cannot add functional edge since an edge of that type already exists", e);
+                } else {
+                    status.change();
+                    content.add(e);
+                }
+            }
+        } else {
+            status.setModified(content.add(e));
+        }
+        return this;
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges(final TitanType type) {
-		if (factory.isUniformTyped()) return getEdges();
-		else return Iterables.filter(getEdges(), new Predicate<InternalRelation>() {
+    @Override
+    public boolean containsEdge(InternalRelation e) {
+        return content.contains(e);
+    }
 
-			@Override
-			public boolean apply(InternalRelation e) {
-				return type.equals(e.getType());
-			}
-			
-		});
-	}
-	
-	@Override
-	public Iterable<InternalRelation> getEdges(final TypeGroup group) {
-		if (factory.isUniformTyped()) return getEdges();
-		else return Iterables.filter(getEdges(), new Predicate<InternalRelation>() {
+    @Override
+    public Iterable<InternalRelation> getEdges() {
+        return content;
+    }
 
-			@Override
-			public boolean apply(InternalRelation e) {
-				return group.equals(e.getType().getGroup());
-			}
-			
-		});
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges(final TitanType type) {
+        if (factory.isUniformTyped()) return getEdges();
 
-	@Override
-	public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
-		if (content.remove(e)) status.nochange();
-		else status.change();
-	}
+        return Iterables.filter(getEdges(), new Predicate<InternalRelation>() {
 
-	@Override
-	public AdjacencyListFactory getFactory() {
-		return factory;
-	}
+            @Override
+            public boolean apply(InternalRelation e) {
+                return type.equals(e.getType());
+            }
 
-	@Override
-	public boolean isEmpty() {
-		return content.isEmpty();
-	}
+        });
+    }
 
-	@Override
-	public Iterator<InternalRelation> iterator() {
-		return getEdges().iterator();
-	}
-	
+    @Override
+    public Iterable<InternalRelation> getEdges(final TypeGroup group) {
+        if (factory.isUniformTyped()) return getEdges();
+        return Iterables.filter(getEdges(), new Predicate<InternalRelation>() {
+
+            @Override
+            public boolean apply(InternalRelation e) {
+                return group.equals(e.getType().getGroup());
+            }
+
+        });
+    }
+
+    @Override
+    public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
+        if (content.remove(e)) {
+            status.nochange();
+        } else {
+            status.change();
+        }
+    }
+
+    @Override
+    public AdjacencyListFactory getFactory() {
+        return factory;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return content.isEmpty();
+    }
+
+    @Override
+    public Iterator<InternalRelation> iterator() {
+        return getEdges().iterator();
+    }
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/TypedAdjListFactory.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/TypedAdjListFactory.java
@@ -4,39 +4,36 @@ import com.thinkaurelius.titan.graphdb.relations.InternalRelation;
 
 public class TypedAdjListFactory implements AdjacencyListFactory {
 
-	private static final int expectedNumEdgeTypes = 5;
+    private static final int expectedNumEdgeTypes = 5;
 
-	public static final TypedAdjListFactory defaultInstance = new TypedAdjListFactory();
-	
-	private TypedAdjListFactory() {
-		
-	}
-	
-	@Override
-	public AdjacencyList emptyList() {
-		return new TypedAdjacencyList(this);
-	}
+    public static final TypedAdjListFactory defaultInstance = new TypedAdjListFactory();
 
-	@Override
-	public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge,
-			ModificationStatus status) {
-		throw new UnsupportedOperationException("There is no extension for typed adjacency lists");
-	}
-	
-	AdjacencyList getEmptyTypeAdjList() {
-		return new ArrayAdjacencyList(ArrayAdjListFactory.uniformSetInstance);
-	}
-	
-	int getInitialCapacity() {
-		return expectedNumEdgeTypes;
-	}
-	
-	int getConcurrencyLevel() {
-		return 1;
-	}
-	
-	float getLoadFactor() {
-		return 0.75f;
-	}
+    private TypedAdjListFactory() {}
+
+    @Override
+    public AdjacencyList emptyList() {
+        return new TypedAdjacencyList(this);
+    }
+
+    @Override
+    public AdjacencyList extend(AdjacencyList list, InternalRelation newEdge, ModificationStatus status) {
+        throw new UnsupportedOperationException("There is no extension for typed adjacency lists");
+    }
+
+    AdjacencyList getEmptyTypeAdjList() {
+        return new ArrayAdjacencyList(ArrayAdjListFactory.uniformSetInstance);
+    }
+
+    int getInitialCapacity() {
+        return expectedNumEdgeTypes;
+    }
+
+    int getConcurrencyLevel() {
+        return 1;
+    }
+
+    float getLoadFactor() {
+        return 0.75f;
+    }
 
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/TypedAdjacencyList.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/adjacencylist/TypedAdjacencyList.java
@@ -12,97 +12,96 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 public class TypedAdjacencyList implements AdjacencyList {
 
-	
-	private final TypedAdjListFactory factory;
-	private ConcurrentSkipListMap<TitanType,AdjacencyList> content;
 
-	TypedAdjacencyList(TypedAdjListFactory factory) {
-		this.factory = factory;
-//		content = new ConcurrentHashMap<TitanType,AdjacencyList>
-//						(factory.getInitialCapacity(),factory.getLoadFactor(),factory.getConcurrencyLevel());
-		content = new ConcurrentSkipListMap<TitanType,AdjacencyList>(TypeComparator.INSTANCE);
-	}
-	
-	TypedAdjacencyList(TypedAdjListFactory factory, AdjacencyList base) {
-		this(factory);
-		for (InternalRelation e : base.getEdges()) {
-			addEdge(e,ModificationStatus.none);
-		}
-	}
-	
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
-		return addEdge(e,false,status);
-	}
+    private final TypedAdjListFactory factory;
+    private ConcurrentSkipListMap<TitanType, AdjacencyList> content;
 
-	@Override
-	public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
-		AdjacencyList list = content.get(e.getType());
-		if (list==null) {
-			list = factory.getEmptyTypeAdjList();
-			checkTypeUniqueness=false;
-			content.put(e.getType(), list);
-		}
-		AdjacencyList newlist = list.addEdge(e, checkTypeUniqueness, status);
-		if (newlist!=list) content.put(e.getType(), newlist);
-		return this;
-	}
+    TypedAdjacencyList(TypedAdjListFactory factory) {
+        this.factory = factory;
+        content = new ConcurrentSkipListMap<TitanType, AdjacencyList>(TypeComparator.INSTANCE);
+    }
 
-	@Override
-	public boolean containsEdge(InternalRelation e) {
-		AdjacencyList list = content.get(e.getType());
-		return list!=null && list.containsEdge(e);
-	}
+    TypedAdjacencyList(TypedAdjListFactory factory, AdjacencyList base) {
+        this(factory);
+        for (InternalRelation e : base.getEdges()) {
+            addEdge(e, ModificationStatus.none);
+        }
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges() {
-		if (content.isEmpty()) return AdjacencyList.Empty;
-		else return Iterables.concat(content.values());
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, ModificationStatus status) {
+        return addEdge(e, false, status);
+    }
 
-	@Override
-	public Iterable<InternalRelation> getEdges(TitanType type) {
-		AdjacencyList list = content.get(type);		
-		if (list==null) return AdjacencyList.Empty;
-		else return list;
-	}
-	
-	@Override
-	public Iterable<InternalRelation> getEdges(TypeGroup group) {
-		if (content.isEmpty()) return AdjacencyList.Empty;
-		else {
-			ConcurrentNavigableMap<TitanType,AdjacencyList> submap = content.subMap(
-						TypeComparator.getGroupComparisonType(group.getID()),
-						TypeComparator.getGroupComparisonType((short) (group.getID() + 1)));
-			return Iterables.concat(submap.values());
-		}
-	}
+    @Override
+    public synchronized AdjacencyList addEdge(InternalRelation e, boolean checkTypeUniqueness, ModificationStatus status) {
+        AdjacencyList list = content.get(e.getType());
+        if (list == null) {
+            list = factory.getEmptyTypeAdjList();
+            checkTypeUniqueness = false;
+            content.put(e.getType(), list);
+        }
+        AdjacencyList newlist = list.addEdge(e, checkTypeUniqueness, status);
+        if (newlist != list) content.put(e.getType(), newlist);
+        return this;
+    }
 
-	@Override
-	public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
-		AdjacencyList list = content.get(e.getType());
-		if (list==null) status.nochange();
-		else list.removeEdge(e, status);
-	}
+    @Override
+    public boolean containsEdge(InternalRelation e) {
+        AdjacencyList list = content.get(e.getType());
+        return list != null && list.containsEdge(e);
+    }
 
-	@Override
-	public AdjacencyListFactory getFactory() {
-		return factory;
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges() {
+        if (content.isEmpty()) return AdjacencyList.Empty;
+        return Iterables.concat(content.values());
+    }
 
-	@Override
-	public boolean isEmpty() {
-		for (AdjacencyList list : content.values()) {
-			if (!list.isEmpty()) return false;
-		}
-		return true;
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges(TitanType type) {
+        AdjacencyList list = content.get(type);
+        if (list == null) return AdjacencyList.Empty;
+        return list;
+    }
 
-	@Override
-	public Iterator<InternalRelation> iterator() {
-		return getEdges().iterator();
-	}
+    @Override
+    public Iterable<InternalRelation> getEdges(TypeGroup group) {
+        if (content.isEmpty()) return AdjacencyList.Empty;
 
+        ConcurrentNavigableMap<TitanType, AdjacencyList> submap = content.subMap(
+                TypeComparator.getGroupComparisonType(group.getID()),
+                TypeComparator.getGroupComparisonType((short) (group.getID() + 1)));
+        return Iterables.concat(submap.values());
 
-	
+    }
+
+    @Override
+    public synchronized void removeEdge(InternalRelation e, ModificationStatus status) {
+        AdjacencyList list = content.get(e.getType());
+        if (list == null) {
+            status.nochange();
+        } else {
+            list.removeEdge(e, status);
+        }
+    }
+
+    @Override
+    public AdjacencyListFactory getFactory() {
+        return factory;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        for (AdjacencyList list : content.values()) {
+            if (!list.isEmpty()) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Iterator<InternalRelation> iterator() {
+        return getEdges().iterator();
+    }
+
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/BasicElement.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/BasicElement.java
@@ -6,15 +6,13 @@ import static com.thinkaurelius.titan.graphdb.entitystatus.LocatedElement.NoID;
 
 public class BasicElement extends VirtualElement {
 
-
-	
 	public BasicElement() {
 		super(true);
 	}
 	
 	public BasicElement(long _id) {
 		super(false);
-		Preconditions.checkArgument(_id>NoID);
+		Preconditions.checkArgument(_id > NoID);
 		id = _id;
 	}
 
@@ -27,17 +25,15 @@ public class BasicElement extends VirtualElement {
 
 	@Override
 	public long getID() {
-		if (!hasID())
-			throw new IllegalStateException("The entity has not yet been assigned an id");
-		else return id;
+		if (!hasID()) throw new IllegalStateException("The entity has not yet been assigned an id");
+		return id;
 	}
 
 	@Override
 	public boolean hasID() {
-		return id>NoID;
+		return id > NoID;
 	}
 
-	
 	@Override
 	public void setID(long id) {
 		Preconditions.checkArgument(isNew(), "Illegal lifecycle status for setting id");
@@ -45,5 +41,4 @@ public class BasicElement extends VirtualElement {
 		if (hasID()) throw new IllegalStateException("The entity has already been assigned an id");
 		this.id = id;
 	}
-	
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/EntityLifeCycle.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/EntityLifeCycle.java
@@ -13,7 +13,6 @@ public class EntityLifeCycle {
 	 */
 	final static byte New = 1;
 
-	
 	/**
 	 * The entity has been loaded from the database and has not changed
 	 * after initial loading.
@@ -29,6 +28,4 @@ public class EntityLifeCycle {
 	 * The entity has been deleted but not yet erased from the database.
 	 */
 	final static byte Deleted = 4;
-
-	
 }

--- a/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/LocatedElement.java
+++ b/src/main/java/com/thinkaurelius/titan/graphdb/entitystatus/LocatedElement.java
@@ -14,7 +14,7 @@ public abstract class LocatedElement implements InternalElement {
 	}
 	
 	public LocatedElement(long _id) {
-		Preconditions.checkArgument(_id>NoID);
+		Preconditions.checkArgument(_id > NoID);
 		id = _id;
 	}
 	
@@ -30,19 +30,19 @@ public abstract class LocatedElement implements InternalElement {
 	@Override
 	public long getID() {
 		if (!hasID()) throw new IllegalStateException("The entity has not yet been assigned an id");
-		else return id;
+        return id;
 	}
 
 	@Override
 	public boolean hasID() {
-		return id>NoID;
+		return id > NoID;
 	}
 
 	
 	@Override
 	public void setID(long id) {
 		Preconditions.checkArgument(isNew());
-		Preconditions.checkArgument(id!=NoID,"Illegal id: " + id);
+		Preconditions.checkArgument(id != NoID, "Illegal id: " + id);
 		if (hasID()) throw new IllegalStateException("The entity has already been assigned an id: " + getID());
 		this.id = id;
 	}

--- a/src/test/java/com/thinkaurelius/titan/StorageSetup.java
+++ b/src/test/java/com/thinkaurelius/titan/StorageSetup.java
@@ -1,8 +1,5 @@
 package com.thinkaurelius.titan;
 
-import com.thinkaurelius.titan.core.TitanFactory;
-import com.thinkaurelius.titan.core.TitanGraph;
-import com.thinkaurelius.titan.diskstorage.cassandra.CassandraThriftStorageManager;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.util.system.IOUtils;
 import org.apache.commons.configuration.BaseConfiguration;
@@ -13,40 +10,39 @@ import java.io.File;
 
 public class StorageSetup {
 
-	public static final String cassandraYamlPath = StringUtils.join(
-			new String[] { "file://", System.getProperty("user.dir"), "target",
-					"cassandra-tmp", "conf", "127.0.0.1", "cassandra.yaml" },
-			File.separator);
-	
+    public static final String cassandraYamlPath = StringUtils.join(
+            new String[]{"file://", System.getProperty("user.dir"), "target",
+                    "cassandra-tmp", "conf", "127.0.0.1", "cassandra.yaml"},
+            File.separator);
+
     public static final String getHomeDir() {
         String homedir = System.getProperty("titan.testdir");
-        if (null ==  homedir) {
-             homedir = System.getProperty("java.io.tmpdir") + File.separator +  "titan-test";
+        if (null == homedir) {
+            homedir = System.getProperty("java.io.tmpdir") + File.separator + "titan-test";
         }
         File homefile = new File(homedir);
         if (!homefile.exists()) homefile.mkdirs();
         return homedir;
     }
-    
+
     public static final File getHomeDirFile() {
         return new File(getHomeDir());
     }
-	
-	public static final void deleteHomeDir() {
-		File homeDirFile = getHomeDirFile();
-		// Make directory if it doesn't exist
-		if (!homeDirFile.exists())
-			homeDirFile.mkdirs();
-		boolean success = IOUtils.deleteFromDirectory(homeDirFile);
-        if (!success) throw new IllegalStateException("Could not remove " + homeDirFile) ;
-	}
+
+    public static final void deleteHomeDir() {
+        File homeDirFile = getHomeDirFile();
+        // Make directory if it doesn't exist
+        if (!homeDirFile.exists()) homeDirFile.mkdirs();
+        boolean success = IOUtils.deleteFromDirectory(homeDirFile);
+        if (!success) throw new IllegalStateException("Could not remove " + homeDirFile);
+    }
 
     public static Configuration getLocalStorageConfiguration() {
         BaseConfiguration config = new BaseConfiguration();
-        config.addProperty(GraphDatabaseConfiguration.STORAGE_DIRECTORY_KEY,getHomeDir());
+        config.addProperty(GraphDatabaseConfiguration.STORAGE_DIRECTORY_KEY, getHomeDir());
         return config;
     }
-    
+
     public static Configuration getBerkeleyJEStorageConfiguration() {
         return getLocalStorageConfiguration();
     }
@@ -56,42 +52,37 @@ public class StorageSetup {
     }
 
     public static Configuration getCassandraStorageConfiguration() {
-        Configuration config = getLocalStorageConfiguration();
-        return config;
+        return getLocalStorageConfiguration();
     }
-
-
-    //------
 
     public static Configuration getLocalGraphConfiguration() {
         BaseConfiguration config = new BaseConfiguration();
-        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_DIRECTORY_KEY,getHomeDir());
+        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_DIRECTORY_KEY, getHomeDir());
         return config;
     }
 
     public static Configuration getBerkeleyJEGraphConfiguration() {
         Configuration config = getLocalGraphConfiguration();
-        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY,"berkeleyje");
+        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY, "berkeleyje");
         return config;
     }
 
     public static Configuration getHBaseGraphConfiguration() {
         Configuration config = StorageSetup.getLocalGraphConfiguration();
-        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY,"hbase");
+        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY, "hbase");
         return config;
     }
-    
+
     public static Configuration getAstyanaxGraphConfiguration() {
         Configuration config = StorageSetup.getLocalGraphConfiguration();
-        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY,"astyanax");
+        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY, "astyanax");
         return config;
     }
 
     public static Configuration getCassandraGraphConfiguration() {
         Configuration config = StorageSetup.getLocalGraphConfiguration();
-        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY,"cassandra");
+        config.subset(GraphDatabaseConfiguration.STORAGE_NAMESPACE).addProperty(GraphDatabaseConfiguration.STORAGE_BACKEND_KEY, "cassandra");
         return config;
     }
-
 
 }

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/KeyColumnValueStoreTest.java
@@ -1,8 +1,6 @@
 package com.thinkaurelius.titan.diskstorage;
 
 
-import com.thinkaurelius.titan.StorageSetup;
-import com.thinkaurelius.titan.diskstorage.util.KeyValueStorageManagerAdapter;
 import com.thinkaurelius.titan.testutil.RandomGenerator;
 import org.junit.After;
 import org.junit.Assert;
@@ -18,424 +16,393 @@ import static org.junit.Assert.*;
 
 public abstract class KeyColumnValueStoreTest {
 
-	private Logger log = LoggerFactory.getLogger(KeyValueStoreTest.class);
+    private Logger log = LoggerFactory.getLogger(KeyValueStoreTest.class);
 
-	int numKeys = 500;
-	int numColumns = 50;
+    int numKeys = 500;
+    int numColumns = 50;
 
     protected String storeName = "testStore1";
-	
-	public StorageManager manager;
-	public TransactionHandle tx;
-	public OrderedKeyColumnValueStore store;
-	
-	@Before
-	public void setUp() throws Exception {
-		openStorageManager().clearStorage();
+
+    public StorageManager manager;
+    public TransactionHandle tx;
+    public OrderedKeyColumnValueStore store;
+
+    @Before
+    public void setUp() throws Exception {
+        openStorageManager().clearStorage();
         open();
-	}
+    }
 
     public abstract StorageManager openStorageManager();
 
-	public void open() {
+    public void open() {
         manager = openStorageManager();
         tx = manager.beginTransaction();
         store = manager.openDatabase(storeName);
     }
-    
+
     public void clopen() {
         close();
         open();
     }
-	
-	@After
-	public void tearDown() throws Exception {
-		close();
-	}
+
+    @After
+    public void tearDown() throws Exception {
+        close();
+    }
 
     public void close() {
-        if (tx!=null) tx.commit();
+        if (tx != null) tx.commit();
         store.close();
         manager.close();
     }
 
     @Test
-	public void createDatabase() {
-		//Just setup and shutdown
-	}
-	
-	
-	public String[][] generateValues() {
-		return KeyValueStoreUtil.generateData(numKeys, numColumns);
-	}
-	
-	public void loadValues(String[][] values) {
-		for (int i=0;i<numKeys;i++) {
-			List<Entry> entries = new ArrayList<Entry>();
-			for (int j=0;j<numColumns;j++) {
-				entries.add(new Entry(KeyValueStoreUtil.getBuffer(j), KeyValueStoreUtil.getBuffer(values[i][j])));
-			}
-			store.mutate(KeyValueStoreUtil.getBuffer(i), entries, null, tx);
-		}
-	}
-	
-	public Set<KeyColumn> deleteValues(int every) {
-		Set<KeyColumn> removed = new HashSet<KeyColumn>();
-		int counter = 0;
-		for (int i=0;i<numKeys;i++) {
-			List<ByteBuffer> deletions = new ArrayList<ByteBuffer>();
-			for (int j=0;j<numColumns;j++) {
-				counter++;
-				if (counter%every==0) {
-					//remove
-					removed.add(new KeyColumn(i,j));
-					deletions.add(KeyValueStoreUtil.getBuffer(j));
-				}
-			}
-			store.mutate(KeyValueStoreUtil.getBuffer(i), null, deletions, tx);
-		}
-		return removed;
-	}
-	
-	public Set<Integer> deleteKeys(int every) {
-		Set<Integer> removed = new HashSet<Integer>();
-		for (int i=0;i<numKeys;i++) {
-			if (i%every==0) {
-				removed.add(i);
-				List<ByteBuffer> deletions = new ArrayList<ByteBuffer>();
-				for (int j=0;j<numColumns;j++) {
-					deletions.add(KeyValueStoreUtil.getBuffer(j));
-				}
-				store.mutate(KeyValueStoreUtil.getBuffer(i), null, deletions, tx);
-			}
-		}
-		return removed;
-	}
-	
-	public void checkKeys(Set<Integer> removed) {
-		for (int i=0;i<numKeys;i++) {
-			if (removed.contains(i)) {
-				assertFalse(store.containsKey(KeyValueStoreUtil.getBuffer(i), tx));
-			} else {
-				assertTrue(store.containsKey(KeyValueStoreUtil.getBuffer(i), tx));
-			}
-		}
-	}
-	
-	public void checkValueExistence(String[][] values) {
-		checkValueExistence(values,new HashSet<KeyColumn>());
-	}
-	
-	public void checkValueExistence(String[][] values, Set<KeyColumn> removed) {
-		for (int i=0;i<numKeys;i++) {
-			for (int j=0;j<numColumns;j++) {
-				boolean result = store.containsKeyColumn(KeyValueStoreUtil.getBuffer(i), KeyValueStoreUtil.getBuffer(j),tx);
-				if (removed.contains(new KeyColumn(i,j))) {
-					assertFalse(result);
-				} else {
-					assertTrue(result);
-				}
-			}
-		}
-	}
-	
-	public void checkValues(String[][] values) {
-		checkValues(values,new HashSet<KeyColumn>());
-	}
-	
-	public void checkValues(String[][] values, Set<KeyColumn> removed) {
-		for (int i=0;i<numKeys;i++) {
-			for (int j=0;j<numColumns;j++) {
-				ByteBuffer result = store.get(KeyValueStoreUtil.getBuffer(i), KeyValueStoreUtil.getBuffer(j),tx);
-				if (removed.contains(new KeyColumn(i,j))) {
-					assertNull(result);
-				} else {
-					Assert.assertEquals(values[i][j], KeyValueStoreUtil.getString(result));
-				}
-			}
-		}
+    public void createDatabase() {
+        //Just setup and shutdown
+    }
 
-	}
-	
-	@Test
-	public void storeAndRetrieve() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		//print(values);
-		log.debug("Checking values...");
-		checkValueExistence(values);
-		checkValues(values);
-	}
-	
-	@Test
-	public void storeAndRetrieveWithClosing() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		clopen();
-		log.debug("Checking values...");
-		checkValueExistence(values);
-		checkValues(values);
-	}
-	
-	@Test
-	public void deleteColumnsTest1() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		clopen();
-		Set<KeyColumn> deleted = deleteValues(7);
-		log.debug("Checking values...");
-		checkValueExistence(values,deleted);
-		checkValues(values,deleted);
-	}
-	
-	@Test
-	public void deleteColumnsTest2() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		Set<KeyColumn> deleted = deleteValues(7);
-		clopen();
-		log.debug("Checking values...");
-		checkValueExistence(values,deleted);
-		checkValues(values,deleted);
-	}
-	
-	@Test
-	public void deleteKeys() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		Set<Integer> deleted = deleteKeys(11);
-		clopen();
-		checkKeys(deleted);
-	}
-	
-	public void checkSlice(String[][] values, Set<KeyColumn> removed, int key, int start, int end, int limit) {
-		List<Entry> entries;
-		if (limit<=0)
-			entries = store.getSlice(KeyValueStoreUtil.getBuffer(key), KeyValueStoreUtil.getBuffer(start), KeyValueStoreUtil.getBuffer(end), tx);
-		else
-			entries = store.getSlice(KeyValueStoreUtil.getBuffer(key), KeyValueStoreUtil.getBuffer(start), KeyValueStoreUtil.getBuffer(end), limit, tx);
-		
-		int pos=0;
-		for (int i=start;i<end;i++) {
-			if (removed.contains(new KeyColumn(key,i))) continue;
-			if (limit<=0 || pos<limit) {
-				Entry entry = entries.get(pos);
-				int col = KeyValueStoreUtil.getID(entry.getColumn());
-				String str = KeyValueStoreUtil.getString(entry.getValue());
-				assertEquals(i,col);
-				assertEquals(values[key][i],str);
-			}
-			pos++;
-		}
+    public String[][] generateValues() {
+        return KeyValueStoreUtil.generateData(numKeys, numColumns);
+    }
+
+    public void loadValues(String[][] values) {
+        for (int i = 0; i < numKeys; i++) {
+            List<Entry> entries = new ArrayList<Entry>();
+            for (int j = 0; j < numColumns; j++) {
+                entries.add(new Entry(KeyValueStoreUtil.getBuffer(j), KeyValueStoreUtil.getBuffer(values[i][j])));
+            }
+            store.mutate(KeyValueStoreUtil.getBuffer(i), entries, null, tx);
+        }
+    }
+
+    public Set<KeyColumn> deleteValues(int every) {
+        Set<KeyColumn> removed = new HashSet<KeyColumn>();
+        int counter = 0;
+        for (int i = 0; i < numKeys; i++) {
+            List<ByteBuffer> deletions = new ArrayList<ByteBuffer>();
+            for (int j = 0; j < numColumns; j++) {
+                counter++;
+                if (counter % every == 0) {
+                    //remove
+                    removed.add(new KeyColumn(i, j));
+                    deletions.add(KeyValueStoreUtil.getBuffer(j));
+                }
+            }
+            store.mutate(KeyValueStoreUtil.getBuffer(i), null, deletions, tx);
+        }
+        return removed;
+    }
+
+    public Set<Integer> deleteKeys(int every) {
+        Set<Integer> removed = new HashSet<Integer>();
+        for (int i = 0; i < numKeys; i++) {
+            if (i % every == 0) {
+                removed.add(i);
+                List<ByteBuffer> deletions = new ArrayList<ByteBuffer>();
+                for (int j = 0; j < numColumns; j++) {
+                    deletions.add(KeyValueStoreUtil.getBuffer(j));
+                }
+                store.mutate(KeyValueStoreUtil.getBuffer(i), null, deletions, tx);
+            }
+        }
+        return removed;
+    }
+
+    public void checkKeys(Set<Integer> removed) {
+        for (int i = 0; i < numKeys; i++) {
+            if (removed.contains(i)) {
+                assertFalse(store.containsKey(KeyValueStoreUtil.getBuffer(i), tx));
+            } else {
+                assertTrue(store.containsKey(KeyValueStoreUtil.getBuffer(i), tx));
+            }
+        }
+    }
+
+    public void checkValueExistence(String[][] values) {
+        checkValueExistence(values, new HashSet<KeyColumn>());
+    }
+
+    public void checkValueExistence(String[][] values, Set<KeyColumn> removed) {
+        for (int i = 0; i < numKeys; i++) {
+            for (int j = 0; j < numColumns; j++) {
+                boolean result = store.containsKeyColumn(KeyValueStoreUtil.getBuffer(i), KeyValueStoreUtil.getBuffer(j), tx);
+                if (removed.contains(new KeyColumn(i, j))) {
+                    assertFalse(result);
+                } else {
+                    assertTrue(result);
+                }
+            }
+        }
+    }
+
+    public void checkValues(String[][] values) {
+        checkValues(values, new HashSet<KeyColumn>());
+    }
+
+    public void checkValues(String[][] values, Set<KeyColumn> removed) {
+        for (int i = 0; i < numKeys; i++) {
+            for (int j = 0; j < numColumns; j++) {
+                ByteBuffer result = store.get(KeyValueStoreUtil.getBuffer(i), KeyValueStoreUtil.getBuffer(j), tx);
+                if (removed.contains(new KeyColumn(i, j))) {
+                    assertNull(result);
+                } else {
+                    Assert.assertEquals(values[i][j], KeyValueStoreUtil.getString(result));
+                }
+            }
+        }
+
+    }
+
+    @Test
+    public void storeAndRetrieve() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        //print(values);
+        log.debug("Checking values...");
+        checkValueExistence(values);
+        checkValues(values);
+    }
+
+    @Test
+    public void storeAndRetrieveWithClosing() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        clopen();
+        log.debug("Checking values...");
+        checkValueExistence(values);
+        checkValues(values);
+    }
+
+    @Test
+    public void deleteColumnsTest1() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        clopen();
+        Set<KeyColumn> deleted = deleteValues(7);
+        log.debug("Checking values...");
+        checkValueExistence(values, deleted);
+        checkValues(values, deleted);
+    }
+
+    @Test
+    public void deleteColumnsTest2() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        Set<KeyColumn> deleted = deleteValues(7);
+        clopen();
+        log.debug("Checking values...");
+        checkValueExistence(values, deleted);
+        checkValues(values, deleted);
+    }
+
+    @Test
+    public void deleteKeys() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        Set<Integer> deleted = deleteKeys(11);
+        clopen();
+        checkKeys(deleted);
+    }
+
+    public void checkSlice(String[][] values, Set<KeyColumn> removed, int key, int start, int end, int limit) {
+        List<Entry> entries;
+        if (limit <= 0)
+            entries = store.getSlice(KeyValueStoreUtil.getBuffer(key), KeyValueStoreUtil.getBuffer(start), KeyValueStoreUtil.getBuffer(end), tx);
+        else
+            entries = store.getSlice(KeyValueStoreUtil.getBuffer(key), KeyValueStoreUtil.getBuffer(start), KeyValueStoreUtil.getBuffer(end), limit, tx);
+
+        int pos = 0;
+        for (int i = start; i < end; i++) {
+            if (removed.contains(new KeyColumn(key, i))) continue;
+            if (limit <= 0 || pos < limit) {
+                Entry entry = entries.get(pos);
+                int col = KeyValueStoreUtil.getID(entry.getColumn());
+                String str = KeyValueStoreUtil.getString(entry.getValue());
+                assertEquals(i, col);
+                assertEquals(values[key][i], str);
+            }
+            pos++;
+        }
         assertNotNull(entries);
-		if (limit>0 && pos>limit) assertEquals(limit, entries.size());
-        else assertEquals(pos,entries.size());
-	}
-	
-	@Test
-	public void intervalTest1() {
-		String[][] values = generateValues();
-		log.debug("Loading values...");
-		loadValues(values);
-		Set<KeyColumn> deleted = deleteValues(7);
-		clopen();
-		int trails = 5000;
-		for (int t=0;t<trails;t++)  {
-			int key = RandomGenerator.randomInt(0, numKeys);
-			int start = RandomGenerator.randomInt(0, numColumns);
-			int end = RandomGenerator.randomInt(start, numColumns);
-			int limit = RandomGenerator.randomInt(1, 30);
-			checkSlice(values,deleted,key,start,end,limit);
-			checkSlice(values,deleted,key,start,end,-1);
-		}
+        if (limit > 0 && pos > limit) assertEquals(limit, entries.size());
+        else assertEquals(pos, entries.size());
+    }
 
-	
-	}
+    @Test
+    public void intervalTest1() {
+        String[][] values = generateValues();
+        log.debug("Loading values...");
+        loadValues(values);
+        Set<KeyColumn> deleted = deleteValues(7);
+        clopen();
+        int trails = 5000;
+        for (int t = 0; t < trails; t++) {
+            int key = RandomGenerator.randomInt(0, numKeys);
+            int start = RandomGenerator.randomInt(0, numColumns);
+            int end = RandomGenerator.randomInt(start, numColumns);
+            int limit = RandomGenerator.randomInt(1, 30);
+            checkSlice(values, deleted, key, start, end, limit);
+            checkSlice(values, deleted, key, start, end, -1);
+        }
 
 
-	@Test
-	public void getNonExistentKeyReturnsNull() throws Exception {
-		TransactionHandle txn = manager.beginTransaction();
-		assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
-		assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
-		txn.commit();
-	}
-	
-	@Test
-	public void insertingGettingAndDeletingSimpleDataWorks() throws Exception {
-		TransactionHandle txn = manager.beginTransaction();
-		KeyColumnValueStoreUtil.insert(store, txn, 0, "col0", "val0");
-		KeyColumnValueStoreUtil.insert(store, txn, 0, "col1", "val1");
-		txn.commit();
-		
-		txn = manager.beginTransaction();
-		assertEquals("val0", KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
-		assertEquals("val1", KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
-		KeyColumnValueStoreUtil.delete(store, txn, 0, "col0");
-		KeyColumnValueStoreUtil.delete(store, txn, 0, "col1");
-		txn.commit();
-		
-		txn = manager.beginTransaction();
-		assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
-		assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
-		txn.commit();
-	}
-	
-//	@Test
-//	public void getSliceNoLimit() throws Exception {
-//		CassandraThriftStorageManager manager = new CassandraThriftStorageManager(keyspace);
-//		CassandraThriftOrderedKeyColumnValueStore store =
-//			manager.openDatabase(dbName);
-//		
-//		TransactionHandle txn = manager.beginTransaction();
-//		KeyColumnValueStoreUtil.insert(store, txn, "key0", "col0", "val0");
-//		KeyColumnValueStoreUtil.insert(store, txn, "key0", "col1", "val1");
-//		txn.commit();
-//		
-//		txn = manager.beginTransaction();
-//		ByteBuffer key0 = KeyColumnValueStoreUtil.stringToByteBuffer("key0");
-//		ByteBuffer col0 = KeyColumnValueStoreUtil.stringToByteBuffer("col0");
-//		ByteBuffer col2 = KeyColumnValueStoreUtil.stringToByteBuffer("col2");
-//		List<Entry> entries = store.getSlice(key0, col0, col2, txn);
-//		assertNotNull(entries);
-//		assertEquals(2, entries.size());
-//		assertEquals("col0", KeyColumnValueStoreUtil.byteBufferToString(entries.get(0).getColumn()));
-//		assertEquals("val0", KeyColumnValueStoreUtil.byteBufferToString(entries.get(0).getValue()));
-//		assertEquals("col1", KeyColumnValueStoreUtil.byteBufferToString(entries.get(1).getColumn()));
-//		assertEquals("val1", KeyColumnValueStoreUtil.byteBufferToString(entries.get(1).getValue()));
-//		
-//		txn.commit();
-//		
-//		store.shutdown();
-//		manager.shutdown();
-//	}
+    }
 
-	@Test
-	public void getSliceRespectsColumnLimit() throws Exception {
-		TransactionHandle txn = manager.beginTransaction();
-		ByteBuffer key = KeyColumnValueStoreUtil.longToByteBuffer(0);
-		
-		final int cols = 1024;
-		
-		List<Entry> entries = new LinkedList<Entry>();
-		for (int i = 0; i < cols; i++) {
-			ByteBuffer col = KeyColumnValueStoreUtil.longToByteBuffer(i);
-			entries.add(new Entry(col, col));
-		}
-		store.mutate(key, entries, null, txn);
-		txn.commit();
-				
-		txn = manager.beginTransaction();
-		ByteBuffer columnStart = KeyColumnValueStoreUtil.longToByteBuffer(0);
-		ByteBuffer columnEnd = KeyColumnValueStoreUtil.longToByteBuffer(cols);
-		/* 
-		 * When limit is greater than or equal to the matching column count,
-		 * all matching columns must be returned.
-		 */
-		List<Entry> result =
-			store.getSlice(key, columnStart, columnEnd, cols, txn);
-		assertEquals(cols, result.size());
-		assertEquals(entries, result);
-		result =
-			store.getSlice(key, columnStart, columnEnd, cols+10, txn);
-		assertEquals(cols, result.size());
-		assertEquals(entries, result);
 
-		/*
-		 * When limit is less the matching column count, the columns up to the
-		 * limit (ordered bytewise) must be returned.
-		 */
-		result = 
-			store.getSlice(key, columnStart, columnEnd, cols-1, txn);
-		assertEquals(cols-1, result.size());
-		entries.remove(entries.size()-1);
-		assertEquals(entries, result);
-		result = 
-			store.getSlice(key, columnStart, columnEnd, 1, txn);
-		assertEquals(1, result.size());
-		List<Entry> firstEntrySingleton = Arrays.asList(entries.get(0));
-		assertEquals(firstEntrySingleton, result);
-		txn.commit();
-	}
-	
-	@Test
-	public void getSliceRespectsAllBoundsInclusionArguments() throws Exception {
-		// Test case where endColumn=startColumn+1
-		ByteBuffer key = KeyColumnValueStoreUtil.longToByteBuffer(0);
-		ByteBuffer columnBeforeStart = KeyColumnValueStoreUtil.longToByteBuffer(776);
-		ByteBuffer columnStart = KeyColumnValueStoreUtil.longToByteBuffer(777);
-		ByteBuffer columnEnd = KeyColumnValueStoreUtil.longToByteBuffer(778);
-		ByteBuffer columnAfterEnd = KeyColumnValueStoreUtil.longToByteBuffer(779);
-		
-		// First insert four test Entries
-		TransactionHandle txn = manager.beginTransaction();
-		List<Entry> entries = Arrays.asList(
-				new Entry(columnBeforeStart, columnBeforeStart),
-				new Entry(columnStart, columnStart),
-				new Entry(columnEnd, columnEnd),
-				new Entry(columnAfterEnd, columnAfterEnd));
-		store.mutate(key, entries, null, txn);
-		txn.commit();
-		
-		// getSlice() with only start inclusive
-		txn = manager.beginTransaction();
+    @Test
+    public void getNonExistentKeyReturnsNull() throws Exception {
+        TransactionHandle txn = manager.beginTransaction();
+        assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
+        assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
+        txn.commit();
+    }
+
+    @Test
+    public void insertingGettingAndDeletingSimpleDataWorks() throws Exception {
+        TransactionHandle txn = manager.beginTransaction();
+        KeyColumnValueStoreUtil.insert(store, txn, 0, "col0", "val0");
+        KeyColumnValueStoreUtil.insert(store, txn, 0, "col1", "val1");
+        txn.commit();
+
+        txn = manager.beginTransaction();
+        assertEquals("val0", KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
+        assertEquals("val1", KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
+        KeyColumnValueStoreUtil.delete(store, txn, 0, "col0");
+        KeyColumnValueStoreUtil.delete(store, txn, 0, "col1");
+        txn.commit();
+
+        txn = manager.beginTransaction();
+        assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col0"));
+        assertEquals(null, KeyColumnValueStoreUtil.get(store, txn, 0, "col1"));
+        txn.commit();
+    }
+
+    @Test
+    public void getSliceRespectsColumnLimit() throws Exception {
+        TransactionHandle txn = manager.beginTransaction();
+        ByteBuffer key = KeyColumnValueStoreUtil.longToByteBuffer(0);
+
+        final int cols = 1024;
+
+        List<Entry> entries = new LinkedList<Entry>();
+        for (int i = 0; i < cols; i++) {
+            ByteBuffer col = KeyColumnValueStoreUtil.longToByteBuffer(i);
+            entries.add(new Entry(col, col));
+        }
+        store.mutate(key, entries, null, txn);
+        txn.commit();
+
+        txn = manager.beginTransaction();
+        ByteBuffer columnStart = KeyColumnValueStoreUtil.longToByteBuffer(0);
+        ByteBuffer columnEnd = KeyColumnValueStoreUtil.longToByteBuffer(cols);
+        /*
+           * When limit is greater than or equal to the matching column count,
+           * all matching columns must be returned.
+           */
+        List<Entry> result =
+                store.getSlice(key, columnStart, columnEnd, cols, txn);
+        assertEquals(cols, result.size());
+        assertEquals(entries, result);
+        result =
+                store.getSlice(key, columnStart, columnEnd, cols + 10, txn);
+        assertEquals(cols, result.size());
+        assertEquals(entries, result);
+
+        /*
+           * When limit is less the matching column count, the columns up to the
+           * limit (ordered bytewise) must be returned.
+           */
+        result =
+                store.getSlice(key, columnStart, columnEnd, cols - 1, txn);
+        assertEquals(cols - 1, result.size());
+        entries.remove(entries.size() - 1);
+        assertEquals(entries, result);
+        result =
+                store.getSlice(key, columnStart, columnEnd, 1, txn);
+        assertEquals(1, result.size());
+        List<Entry> firstEntrySingleton = Arrays.asList(entries.get(0));
+        assertEquals(firstEntrySingleton, result);
+        txn.commit();
+    }
+
+    @Test
+    public void getSliceRespectsAllBoundsInclusionArguments() throws Exception {
+        // Test case where endColumn=startColumn+1
+        ByteBuffer key = KeyColumnValueStoreUtil.longToByteBuffer(0);
+        ByteBuffer columnBeforeStart = KeyColumnValueStoreUtil.longToByteBuffer(776);
+        ByteBuffer columnStart = KeyColumnValueStoreUtil.longToByteBuffer(777);
+        ByteBuffer columnEnd = KeyColumnValueStoreUtil.longToByteBuffer(778);
+        ByteBuffer columnAfterEnd = KeyColumnValueStoreUtil.longToByteBuffer(779);
+
+        // First insert four test Entries
+        TransactionHandle txn = manager.beginTransaction();
+        List<Entry> entries = Arrays.asList(
+                new Entry(columnBeforeStart, columnBeforeStart),
+                new Entry(columnStart, columnStart),
+                new Entry(columnEnd, columnEnd),
+                new Entry(columnAfterEnd, columnAfterEnd));
+        store.mutate(key, entries, null, txn);
+        txn.commit();
+
+        // getSlice() with only start inclusive
+        txn = manager.beginTransaction();
         List<Entry> result = store.getSlice(key, columnStart, columnEnd, txn);
-		assertEquals(1, result.size());
-		assertEquals(777, result.get(0).getColumn().getLong());
-		txn.commit();
+        assertEquals(1, result.size());
+        assertEquals(777, result.get(0).getColumn().getLong());
+        txn.commit();
 
-	}
+    }
 
 
     @Test
     public void containsKeyReturnsTrueOnExtantKey() throws Exception {
-        ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
+        ByteBuffer key = KeyColumnValueStoreUtil.longToByteBuffer(1);
         TransactionHandle txn = manager.beginTransaction();
-        assertFalse(store.containsKey(key1.duplicate(), txn));
+        assertFalse(store.containsKey(key.duplicate(), txn));
         KeyColumnValueStoreUtil.insert(store, txn, 1, "c", "v");
         txn.commit();
 
         txn = manager.beginTransaction();
-        assertTrue(store.containsKey(key1.duplicate(), txn));
+        assertTrue(store.containsKey(key.duplicate(), txn));
         txn.commit();
     }
 
-	
-	@Test
-	public void containsKeyReturnsFalseOnNonexistentKey() throws Exception {
+
+    @Test
+    public void containsKeyReturnsFalseOnNonexistentKey() throws Exception {
         TransactionHandle txn = manager.beginTransaction();
         ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
         assertFalse(store.containsKey(key1.duplicate(), txn));
         txn.commit();
-	}
-	
+    }
 
-	
-	@Test
-	public void containsKeyColumnReturnsFalseOnNonexistentInput() throws Exception {
-		TransactionHandle txn = manager.beginTransaction();
-		ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
-		ByteBuffer c = KeyColumnValueStoreUtil.stringToByteBuffer("c");
-		assertFalse(store.containsKeyColumn(key1.duplicate(), c.duplicate(), txn));
-		txn.commit();
-	}
-	
-	@Test
-	public void containsKeyColumnReturnsTrueOnExtantInput() throws Exception {
-		TransactionHandle txn = manager.beginTransaction();
-		KeyColumnValueStoreUtil.insert(store, txn, 1, "c", "v");
-		txn.commit();
 
-		txn = manager.beginTransaction();
-		ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
-		ByteBuffer c = KeyColumnValueStoreUtil.stringToByteBuffer("c");
-		assertTrue(store.containsKeyColumn(key1.duplicate(), c.duplicate(), txn));
-		txn.commit();
-	}
+    @Test
+    public void containsKeyColumnReturnsFalseOnNonexistentInput() throws Exception {
+        TransactionHandle txn = manager.beginTransaction();
+        ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
+        ByteBuffer c = KeyColumnValueStoreUtil.stringToByteBuffer("c");
+        assertFalse(store.containsKeyColumn(key1.duplicate(), c.duplicate(), txn));
+        txn.commit();
+    }
+
+    @Test
+    public void containsKeyColumnReturnsTrueOnExtantInput() throws Exception {
+        TransactionHandle txn = manager.beginTransaction();
+        KeyColumnValueStoreUtil.insert(store, txn, 1, "c", "v");
+        txn.commit();
+
+        txn = manager.beginTransaction();
+        ByteBuffer key1 = KeyColumnValueStoreUtil.longToByteBuffer(1);
+        ByteBuffer c = KeyColumnValueStoreUtil.stringToByteBuffer("c");
+        assertTrue(store.containsKeyColumn(key1.duplicate(), c.duplicate(), txn));
+        txn.commit();
+    }
 }
  

--- a/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxKeyColumnValueTest.java
+++ b/src/test/java/com/thinkaurelius/titan/diskstorage/astyanax/InternalAstyanaxKeyColumnValueTest.java
@@ -1,12 +1,10 @@
 package com.thinkaurelius.titan.diskstorage.astyanax;
 
-import org.junit.BeforeClass;
-
 import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.diskstorage.KeyColumnValueStoreTest;
 import com.thinkaurelius.titan.diskstorage.StorageManager;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraDaemonWrapper;
-import com.thinkaurelius.titan.testutil.CassandraUtil;
+import org.junit.BeforeClass;
 
 public class InternalAstyanaxKeyColumnValueTest extends KeyColumnValueStoreTest {
 


### PR DESCRIPTION
- Whitespace for many is a highly personal thing, but the very compact style in the code now seems much more reminiscent of C++ than Java. Consistent whitespace sets a standard that many contributors will appreciate.
  *\* _id > NoID is easier to read than _id>NoID
  *\* Have a look at the changes in the com.thinkaurelius.titan.graphdb.adjacencylist package in this pull request to see the difference. I use IntelliJ to apply code formatting rules automatically; if you like this style, let me know and I'll make the format consistent. 
- else after an if statement that returns a response is redundant and adds a deeper level of nesting, making the code that much harder to read. See BasicElement and ArrayAdjacencyList for examples.
- if statements used as guard clauses don't need braces.
- if / else blocks should have braces for readability.
- removed unused imports.
- Fixed a redundant cast in ArrayAdjListFactory
- Remove commented code. It gets out of date and wastes the time of people who stop to read it to figure out what it _might_ be good for. Store experiments on a feature branch.
