### PR TITLE
Fix stale lock bug in LockingTransactionHandle

### DIFF
--- a/src/main/java/com/thinkaurelius/titan/diskstorage/locking/LockingTransactionHandle.java
+++ b/src/main/java/com/thinkaurelius/titan/diskstorage/locking/LockingTransactionHandle.java
@@ -161,7 +161,6 @@ public abstract class LockingTransactionHandle implements TransactionHandle {
 				if (backer.getLockWaitMS() < after - before) {
 					// Too slow
 					// Delete lock claim and loop again
-					tsNS = TimestampProvider.getApproxNSSinceEpoch(false);
 					backer.getLockStore().mutate(lockKey, null, Arrays.asList(lc.getLockCol(tsNS, backer.getRid())), null);
 				} else {
 					ok = true;


### PR DESCRIPTION
This fixes a bug where locks can be left in a cassandra db when the lock creation process is too slow.
