### PR TITLE
Use containsKey not contains

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryKeyColumnValueStore.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryKeyColumnValueStore.java
@@ -209,7 +209,7 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
     private Lock getLock(ByteBuffer key, StoreTransaction txh) {
         if (txh.getConsistencyLevel()==ConsistencyLevel.KEY_CONSISTENT) {
             ByteBuffer dupKey = key.duplicate();
-            if (!keyLocks.contains(dupKey)) {
+            if (!keyLocks.containsKey(dupKey)) {
                 keyLocks.putIfAbsent(dupKey,new ReentrantLock());
             }
             return keyLocks.get(dupKey);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
@@ -78,7 +78,7 @@ public class InMemoryStoreManager implements KeyColumnValueStoreManager {
 
     @Override
     public KeyColumnValueStore openDatabase(final String name) throws StorageException {
-        if (!stores.contains(name)) {
+        if (!stores.containsKey(name)) {
             stores.putIfAbsent(name,new InMemoryKeyColumnValueStore(name));
         }
         KeyColumnValueStore store = stores.get(name);


### PR DESCRIPTION
Code uses contains as a guard against doing a put, but contains checks values, not keys...so that test will always succeed (as contains will always return false) ..  use containsKey instead.
