### PR TITLE
bump Astyanax to 1.56.37

### DIFF
--- a/titan-cassandra/pom.xml
+++ b/titan-cassandra/pom.xml
@@ -10,7 +10,9 @@
     <artifactId>titan-cassandra</artifactId>
     <name>Titan-Cassandra: Distributed Graph Database</name>
     <url>http://thinkaurelius.github.com/titan/</url>
-
+    <properties>
+        <astyanax.version>1.56.37</astyanax.version>
+    </properties>
     <!-- Libraries -->
     <dependencies>
         <dependency>
@@ -77,8 +79,18 @@
         </dependency>
         <dependency>
             <groupId>com.netflix.astyanax</groupId>
-            <artifactId>astyanax</artifactId>
-            <version>1.0.6</version>
+            <artifactId>astyanax-core</artifactId>
+            <version>${astyanax.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.astyanax</groupId>
+            <artifactId>astyanax-thrift</artifactId>
+            <version>${astyanax.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.astyanax</groupId>
+            <artifactId>astyanax-cassandra</artifactId>
+            <version>${astyanax.version}</version>
         </dependency>
         <!-- The latest Snappy-java because 1.4.0.1 is broken on Mac OS X with JDK 7 -->
         <dependency>

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxOrderedKeyColumnValueStore.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxOrderedKeyColumnValueStore.java
@@ -176,15 +176,11 @@ public class AstyanaxOrderedKeyColumnValueStore implements
     }
 
     @Override
-    public void mutate(ByteBuffer key, List<Entry> additions,
-                       List<ByteBuffer> deletions, StoreTransaction txh) throws StorageException {
-        Map<ByteBuffer, KCVMutation> mutations = ImmutableMap.of(key, new
-                KCVMutation(additions, deletions));
-        mutateMany(mutations, txh);
+    public void mutate(ByteBuffer key, List<Entry> additions, List<ByteBuffer> deletions, StoreTransaction txh) throws StorageException {
+        mutateMany(ImmutableMap.of(key, new KCVMutation(additions, deletions)), txh);
     }
 
-    public void mutateMany(Map<ByteBuffer, KCVMutation> mutations,
-                           StoreTransaction txh) throws StorageException {
+    public void mutateMany(Map<ByteBuffer, KCVMutation> mutations, StoreTransaction txh) throws StorageException {
         storeManager.mutateMany(ImmutableMap.of(columnFamilyName, mutations), txh);
     }
 


### PR DESCRIPTION
That version officially suports Cassandra 1.2, changed deprecated methods and made sure that batch mutate command still behaves the way expected.
