### PR TITLE
Added support for Rexster 2.4.0 Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target/
 titan-hbase/logs
 titan-hbase/src/test/titan-hbase-test-data/*
 titan-hbase/src/test/titan-zookeeper-test/*
+.classpath
+.project
+*.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <titan.version>0.3.1</titan.version>
         <titan.compatible.versions>0.3.1,0.3.0</titan.compatible.versions>
-        <tinkerpop.version>2.3.0</tinkerpop.version>
+        <tinkerpop.version>2.4.0-SNAPSHOT</tinkerpop.version>
         <junit.version>4.8.1</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/titan-all/pom.xml
+++ b/titan-all/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>titan-es</artifactId>
             <version>${titan.version}</version>
         </dependency>
+        <dependency>
+			<groupId>com.yammer.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>3.0.0-BETA1</version>
+		</dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/titan-all/pom.xml
+++ b/titan-all/pom.xml
@@ -31,11 +31,6 @@
             <artifactId>titan-es</artifactId>
             <version>${titan.version}</version>
         </dependency>
-        <dependency>
-			<groupId>com.yammer.metrics</groupId>
-			<artifactId>metrics-core</artifactId>
-			<version>3.0.0-BETA1</version>
-		</dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/blueprints/TitanFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/blueprints/TitanFeatures.java
@@ -29,7 +29,6 @@ public class TitanFeatures {
         features.supportsStringProperty = true;
         features.ignoresSuppliedIds = true;
         features.isPersistent = true;
-        features.isRDFModel = false;
         features.isWrapper = false;
         features.supportsIndices = false;
         features.supportsVertexIndex = false;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
@@ -18,7 +18,10 @@ import com.thinkaurelius.titan.graphdb.relations.AttributeUtil;
 import com.thinkaurelius.titan.graphdb.transaction.StandardTitanTx;
 import com.thinkaurelius.titan.util.stats.ObjectAccumulator;
 import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Vertex;
+
+import org.apache.commons.lang.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,6 +83,11 @@ public class TitanGraphQueryBuilder implements TitanGraphQuery, QueryOptimizer<S
         }
         return this;
     }
+
+	@Override
+	public <T extends Comparable<T>> GraphQuery has(String arg0, Compare arg1, T arg2) {
+		throw new NotImplementedException();
+	}
 
 
     @Override

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
@@ -21,7 +21,6 @@ import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.GraphQuery;
 import com.tinkerpop.blueprints.Vertex;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,10 +83,10 @@ public class TitanGraphQueryBuilder implements TitanGraphQuery, QueryOptimizer<S
         return this;
     }
 
-	@Override
-	public <T extends Comparable<T>> GraphQuery has(String arg0, Compare arg1, T arg2) {
-		throw new NotImplementedException();
-	}
+    @Override
+    public <T extends Comparable<T>> GraphQuery has(String s, Compare compare, T t) {
+    	return has(s,Cmp.convert(compare),t);
+    }
 
 
     @Override

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/VertexCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/VertexCentricQueryBuilder.java
@@ -18,8 +18,6 @@ import com.tinkerpop.blueprints.VertexQuery;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.NotImplementedException;
-
 import java.util.*;
 
 public class VertexCentricQueryBuilder implements TitanVertexQuery {
@@ -220,15 +218,15 @@ public class VertexCentricQueryBuilder implements TitanVertexQuery {
         return addConstraint(key,Cmp.convert(compare),value);
     }
 
+    @Override
+    public <T extends Comparable<T>> VertexQuery has(String key, Compare compare, T value) {
+    	return addConstraint(key,Cmp.convert(compare),value);
+    }
+
     public <T extends Comparable<T>> VertexCentricQueryBuilder has(TitanKey key, T value, Compare compare) {
         return has(key.getName(),value,compare);
     }
-
-	@Override
-	public <T extends Comparable<T>> VertexQuery has(String arg0, Compare arg1, T arg2) {
-		throw new NotImplementedException();
-	}
-
+    
     @Override
     public VertexCentricQueryBuilder types(TitanType... type) {
         for (TitanType t : type) type(t);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/VertexCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/VertexCentricQueryBuilder.java
@@ -14,8 +14,12 @@ import com.thinkaurelius.titan.graphdb.relations.AttributeUtil;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Edge;
 import com.tinkerpop.blueprints.Vertex;
+import com.tinkerpop.blueprints.VertexQuery;
 
 import javax.annotation.Nullable;
+
+import org.apache.commons.lang.NotImplementedException;
+
 import java.util.*;
 
 public class VertexCentricQueryBuilder implements TitanVertexQuery {
@@ -219,6 +223,11 @@ public class VertexCentricQueryBuilder implements TitanVertexQuery {
     public <T extends Comparable<T>> VertexCentricQueryBuilder has(TitanKey key, T value, Compare compare) {
         return has(key.getName(),value,compare);
     }
+
+	@Override
+	public <T extends Comparable<T>> VertexQuery has(String arg0, Compare arg1, T arg2) {
+		throw new NotImplementedException();
+	}
 
     @Override
     public VertexCentricQueryBuilder types(TitanType... type) {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/RexsterTitanServer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/RexsterTitanServer.java
@@ -6,6 +6,8 @@ import com.thinkaurelius.titan.core.TitanGraph;
 import com.tinkerpop.rexster.Tokens;
 import com.tinkerpop.rexster.protocol.EngineController;
 import com.tinkerpop.rexster.server.*;
+import com.tinkerpop.rexster.server.metrics.ReporterConfig;
+
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -38,7 +40,7 @@ public class RexsterTitanServer {
     public static final int SHUTDOWN_PORT_VALUE = RexsterSettings.DEFAULT_SHUTDOWN_PORT;
 
     private final Configuration titanConfig;
-    private final Configuration rexsterConfig;
+    private final XMLConfiguration rexsterConfig;
 
     private RexProRexsterServer rexProServer = null;
     private HttpRexsterServer httpServer = null;
@@ -74,6 +76,11 @@ public class RexsterTitanServer {
         final RexsterApplication ra = new TitanRexsterApplication(DEFAULT_GRAPH_NAME, graph, extensionConfigurations);
         startRexProServer(ra);
         startHttpServer(ra);
+
+        final ReporterConfig reporterConfig = ReporterConfig.load(this.rexsterConfig.configurationsAt(Tokens.REXSTER_REPORTER_PATH), ra.getMetricRegistry());
+        this.rexsterConfig.addProperty("http-reporter-enabled", reporterConfig.isHttpReporterEnabled());
+        this.rexsterConfig.addProperty("http-reporter-duration", reporterConfig.getDurationTimeUnitConversion());
+        this.rexsterConfig.addProperty("http-reporter-convert", reporterConfig.getRateTimeUnitConversion());
     }
 
     public void startDaemon() {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/RexsterTitanServer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/tinkerpop/rexster/RexsterTitanServer.java
@@ -81,6 +81,7 @@ public class RexsterTitanServer {
         this.rexsterConfig.addProperty("http-reporter-enabled", reporterConfig.isHttpReporterEnabled());
         this.rexsterConfig.addProperty("http-reporter-duration", reporterConfig.getDurationTimeUnitConversion());
         this.rexsterConfig.addProperty("http-reporter-convert", reporterConfig.getRateTimeUnitConversion());
+        reporterConfig.enable();
     }
 
     public void startDaemon() {

--- a/titan-test/src/main/java/com/thinkaurelius/titan/blueprints/TitanSpecificBlueprintsTestSuite.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/blueprints/TitanSpecificBlueprintsTestSuite.java
@@ -18,7 +18,10 @@ public class TitanSpecificBlueprintsTestSuite extends TestSuite {
         TransactionalGraph graph = (TransactionalGraph) graphTest.generateGraph();
         Vertex a = graph.addVertex(null);
         Vertex b = graph.addVertex(null);
-        Edge e = graph.addEdge(null, a, b, convertId(graph, "friend"));
+        Assert.fail("ZK failed test due to the line of code below: "+
+        	"The method convertId(TransactionalGraph, String) "+
+        	"is undefined for the type TitanSpecificBlueprintsTestSuite");
+        //ZK Edge e = graph.addEdge(null, a, b, convertId(graph, "friend"));
         graph.commit();
 
         a = graph.getVertex(a);


### PR DESCRIPTION
This updates Titan to use TinkerPop 2.4.0-SNAPSHOT.  

Support for Metrics in Titan is dependent upon these changes in Rexster 2.4.0: https://github.com/tinkerpop/rexster/pull/307

I was able to get the metrics to work by making `ReporterConfig` setup occur first -- I had to move `RexProRexsterServer` and `HttpRexsterServer` instantiation out of the `RextsterTitanServer` constructor and into the `start` method instead.  It seems to work fine, and I suppose it shouldn't cause an issue as long as `start` is only called once.

There was one issue in `TitanSpecificBlueprintsTestSuite` that I didn't know how to fix. This particular test should fail every time.

More discussion about Titan Metrics: https://github.com/thinkaurelius/titan/issues/268
