### PR TITLE
Allow IN-unique and OUT-unique edges to have primary keys

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardTypeMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardTypeMaker.java
@@ -78,7 +78,7 @@ public class StandardTypeMaker implements TypeMaker {
         checkSignature(signature);
         Preconditions.checkArgument(Sets.intersection(Sets.newHashSet(primaryKey),Sets.newHashSet(signature)).isEmpty(),
                 "Signature and primary key must be disjoined");
-        if ((isUnique[0] || isUnique[1]) && !primaryKey.isEmpty()) throw new IllegalArgumentException("Cannot define a primary key on a unique type");
+        if ((isUnique[0] && isUnique[1]) && !primaryKey.isEmpty()) throw new IllegalArgumentException("Cannot define a primary key on a unique type");
     }
 
     private static long[] checkPrimaryKey(List<TitanType> sig) {


### PR DESCRIPTION
I tested this change on a local Berkeley database and on my EmbeddedCassandra cluster -- it was successful for both. I'm sure this would need more thorough review, but these early tests show that it works for simple scenarios.

The following use case explains why this change is important to me:

> One million Factors all "use" Artifact X. Each Factor may "use" only one Artifact (OUT unique). Along a user's traversal path, they hit Artifact X. They want to find all Factors which "use" Artifact X and have a FactorType property value of 123.  If I added FactorType as a primary key to the "use" edge, the documentation shows that I would see a dramatic performance improvement. However, because the "use" edge is OUT unique, I can't add a primary key.

The test results show that this _does_ provide a dramatic performance improvement.

I can't get Titan tests to pass in Eclipse (for any branch), so I don't know if this change will cause any existing tests to fail.

Tests and details:
https://gist.github.com/zachkinstner/5630877

Discussion on this topic:
https://groups.google.com/forum/#!topic/aureliusgraphs/KFVtfC9Xy94
