### PR TITLE
resolved unnecessary maven module dependencies

### DIFF
--- a/titan-all/pom.xml
+++ b/titan-all/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>titan-es</artifactId>
             <version>${titan.version}</version>
         </dependency>
+        <dependency>
+        	<groupId>com.thinkaurelius.titan</groupId>
+        	<artifactId>titan-lucene</artifactId>
+        	<version>${titan.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/titan-cassandra/pom.xml
+++ b/titan-cassandra/pom.xml
@@ -26,11 +26,6 @@
             <version>${titan.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.thinkaurelius.titan</groupId>
-            <artifactId>titan-es</artifactId>
-            <version>${titan.version}</version>
-        </dependency>
         <!--
             JNA is not required to run Cassandra, but it improves
             efficiency of certain of Cassandra's filesystem and memory

--- a/titan-hbase/pom.xml
+++ b/titan-hbase/pom.xml
@@ -23,11 +23,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.thinkaurelius.titan</groupId>
-            <artifactId>titan-es</artifactId>
-            <version>${titan.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase</artifactId>
             <!-- Update the hadoop-core artifact version when you update this -->


### PR DESCRIPTION
Removed dependency on titan-es for titan-cassandra and titan-hbase.

titan-berkeleyje still has this dependency for a specific test (ElasticSearchBerkeleyDBTest.java). 

Is this test really necessary? Both other storage backends do not have such tests that depend on a specific indexing backend implementation. If this test could be removed, so could the final dependency between two concrete backend implementations.
