### PR TITLE
Upgrade to Lucene 4.2.0 to resolve runtime error

### DIFF
--- a/titan-lucene/pom.xml
+++ b/titan-lucene/pom.xml
@@ -25,17 +25,17 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-spatial</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
     </dependencies>
     <profiles>


### PR DESCRIPTION
ElasticSearch 0.90 uses Lucene 4.2, but Titan-Lucene used 4.1. This caused the following runtime error:

``` text```
java.lang.NoSuchFieldError: LUCENE_42
```

Full output from `titan.sh`:

``` text
zachkinstner$ bin/titan.sh rexster.xml titan.index.properties
13/06/14 08:27:58 INFO diskstorage.Backend: Configuring index [search] based on: 
 backend: elasticsearch
directory: data/FabricIndex/Elastic
client-only: false
local-mode: true

Exception in thread "main" java.lang.IllegalArgumentException: Could not instantiate implementation: com.thinkaurelius.titan.diskstorage.es.ElasticSearchIndex
    at com.thinkaurelius.titan.diskstorage.Backend.getImplementationClass(Backend.java:295)
    at com.thinkaurelius.titan.diskstorage.Backend.getIndexes(Backend.java:266)
    at com.thinkaurelius.titan.diskstorage.Backend.<init>(Backend.java:101)
    at com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.getBackend(GraphDatabaseConfiguration.java:579)
    at com.thinkaurelius.titan.graphdb.database.StandardTitanGraph.<init>(StandardTitanGraph.java:67)
    at com.thinkaurelius.titan.core.TitanFactory.open(TitanFactory.java:40)
    at com.thinkaurelius.titan.tinkerpop.rexster.RexsterTitanServer.start(RexsterTitanServer.java:61)
    at com.thinkaurelius.titan.tinkerpop.rexster.RexsterTitanServer.startDaemon(RexsterTitanServer.java:114)
    at com.thinkaurelius.titan.tinkerpop.rexster.RexsterTitanServer.main(RexsterTitanServer.java:152)
Caused by: java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:39)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:27)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:513)
    at com.thinkaurelius.titan.diskstorage.Backend.getImplementationClass(Backend.java:284)
    ... 8 more
Caused by: java.lang.NoSuchFieldError: LUCENE_42
    at org.elasticsearch.Version.<clinit>(Version.java:120)
    at org.elasticsearch.node.internal.InternalNode.<init>(InternalNode.java:119)
    at org.elasticsearch.node.NodeBuilder.build(NodeBuilder.java:159)
    at org.elasticsearch.node.NodeBuilder.node(NodeBuilder.java:166)
    at com.thinkaurelius.titan.diskstorage.es.ElasticSearchIndex.<init>(ElasticSearchIndex.java:123)
    ... 13 more
```

The runtime error no longer occurs after making this version update.
