### PR TITLE
Add prefix querying to Lucene and Elasticsearch backends and regexp querying to Elasticsearch backend.

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
@@ -53,7 +53,28 @@ public enum Text implements Relation {
             return condition!=null && condition instanceof String;
         }
 
-    };
+    },
+	
+	/**
+	 * Whether the text matches the given regular expression
+	 */
+	REGEXP {
+	
+	    @Override
+        public boolean satisfiesCondition(Object value, Object condition) {
+            Preconditions.checkArgument(condition instanceof String);
+            if (value==null) return false;
+            if (!(value instanceof String)) log.debug("Value not a string: " + value);
+            return value.toString().startsWith((String)condition);
+        }
+
+        @Override
+        public boolean isValidCondition(Object condition) {
+			if (condition==null) return false;
+            else if (condition instanceof String && StringUtils.isNotBlank((String)condition)) return true;
+            else return false;
+        }
+	};
 
     private static final Logger log = LoggerFactory.getLogger(Text.class);
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
@@ -54,12 +54,12 @@ public enum Text implements Relation {
         }
 
     },
-	
-	/**
-	 * Whether the text matches the given regular expression
-	 */
-	REGEXP {
-	
+
+   /**
+    * Whether the text matches the given regular expression
+    */
+    REGEXP {
+
 	    @Override
         public boolean satisfiesCondition(Object value, Object condition) {
             Preconditions.checkArgument(condition instanceof String);
@@ -70,11 +70,11 @@ public enum Text implements Relation {
 
         @Override
         public boolean isValidCondition(Object condition) {
-			if (condition==null) return false;
+            if (condition==null) return false;
             else if (condition instanceof String && StringUtils.isNotBlank((String)condition)) return true;
             else return false;
         }
-	};
+    };
 
     private static final Logger log = LoggerFactory.getLogger(Text.class);
 

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -332,17 +332,14 @@ public class ElasticSearchIndex implements IndexProvider {
                     }
                 }
             } else if (value instanceof String) {
-                if (relation == Text.CONTAINS) {
-                    return FilterBuilders.termFilter(key,((String)value).toLowerCase());
-//                } else if (relation == Txt.PREFIX) {
-//                    return new PrefixFilter(new Term(key+STR_SUFFIX,(String)value));
-//                } else if (relation == Cmp.EQUAL) {
-//                    return new TermsFilter(new Term(key+STR_SUFFIX,(String)value));
-//                } else if (relation == Cmp.NOT_EQUAL) {
-//                    BooleanFilter q = new BooleanFilter();
-//                    q.add(new TermsFilter(new Term(key+STR_SUFFIX,(String)value)), BooleanClause.Occur.MUST_NOT);
-//                    return q;
-                } else throw new IllegalArgumentException("Relation is not supported for string value: " + relation);
+				if(relation == Text.CONTAINS)
+					return FilterBuilders.termFilter(key,((String)value).toLowerCase());
+				else if(relation == Text.REGEXP)
+					return FilterBuilders.regexpFilter(key,(String)value).cache(true);
+				else if(relation == Text.PREFIX)
+					return FilterBuilders.prefixFilter(key,((String)value).toLowerCase()).cache(true);
+				else
+					throw new IllegalArgumentException("Relation is not supported for string value: " + relation);
             } else if (value instanceof Geoshape) {
                 Preconditions.checkArgument(relation==Geo.WITHIN,"Relation is not supported for geo value: " + relation);
                 Geoshape shape = (Geoshape)value;
@@ -403,7 +400,7 @@ public class ElasticSearchIndex implements IndexProvider {
         } else if (dataType == Geoshape.class) {
             return relation== Geo.WITHIN;
         } else if (dataType == String.class) {
-            return relation == Text.CONTAINS; // || relation == Txt.PREFIX || relation == Cmp.EQUAL || relation == Cmp.NOT_EQUAL;
+            return relation == Text.CONTAINS || relation == Text.PREFIX || relation == Text.REGEXP;
         } else return false;
     }
 

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -332,14 +332,14 @@ public class ElasticSearchIndex implements IndexProvider {
                     }
                 }
             } else if (value instanceof String) {
-				if(relation == Text.CONTAINS)
-					return FilterBuilders.termFilter(key,((String)value).toLowerCase());
-				else if(relation == Text.REGEXP)
-					return FilterBuilders.regexpFilter(key,(String)value).cache(true);
-				else if(relation == Text.PREFIX)
-					return FilterBuilders.prefixFilter(key,((String)value).toLowerCase()).cache(true);
-				else
-					throw new IllegalArgumentException("Relation is not supported for string value: " + relation);
+                if(relation == Text.CONTAINS)
+                    return FilterBuilders.termFilter(key,((String)value).toLowerCase());
+                else if(relation == Text.REGEXP)
+                    return FilterBuilders.regexpFilter(key,(String)value).cache(true);
+                else if(relation == Text.PREFIX)
+                    return FilterBuilders.prefixFilter(key,((String)value).toLowerCase()).cache(true);
+                else
+                    throw new IllegalArgumentException("Relation is not supported for string value: " + relation);
             } else if (value instanceof Geoshape) {
                 Preconditions.checkArgument(relation==Geo.WITHIN,"Relation is not supported for geo value: " + relation);
                 Geoshape shape = (Geoshape)value;

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
@@ -48,14 +48,14 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         assertFalse(index.supports(Exception.class));
 
         assertTrue(index.supports(String.class, Text.CONTAINS));
-		assertTrue(index.supports(String.class, Text.REGEXP));
-		assertTrue(index.supports(String.class, Text.PREFIX));
-		
+        assertTrue(index.supports(String.class, Text.REGEXP));
+        assertTrue(index.supports(String.class, Text.PREFIX));
+
         assertTrue(index.supports(Double.class, Cmp.EQUAL));
         assertTrue(index.supports(Double.class, Cmp.GREATER_THAN_EQUAL));
         assertTrue(index.supports(Double.class, Cmp.LESS_THAN));
         assertTrue(index.supports(Long.class, Cmp.INTERVAL));
-		
+
         assertTrue(index.supports(Geoshape.class, Geo.WITHIN));
 
         assertFalse(index.supports(Double.class, Geo.INTERSECT));

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
@@ -48,13 +48,16 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         assertFalse(index.supports(Exception.class));
 
         assertTrue(index.supports(String.class, Text.CONTAINS));
+		assertTrue(index.supports(String.class, Text.REGEXP));
+		assertTrue(index.supports(String.class, Text.PREFIX));
+		
         assertTrue(index.supports(Double.class, Cmp.EQUAL));
         assertTrue(index.supports(Double.class, Cmp.GREATER_THAN_EQUAL));
         assertTrue(index.supports(Double.class, Cmp.LESS_THAN));
         assertTrue(index.supports(Long.class, Cmp.INTERVAL));
+		
         assertTrue(index.supports(Geoshape.class, Geo.WITHIN));
 
-        assertFalse(index.supports(String.class, Text.PREFIX));
         assertFalse(index.supports(Double.class, Geo.INTERSECT));
         assertFalse(index.supports(Long.class, Text.CONTAINS));
         assertFalse(index.supports(Geoshape.class, Geo.DISJOINT));

--- a/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
+++ b/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
@@ -304,7 +304,7 @@ public class LuceneIndex implements IndexProvider {
             } else if (value instanceof String) {
                 if (relation == Text.CONTAINS) {
                     return new TermsFilter(new Term(key,((String)value).toLowerCase()));
-                } else if (relation == Txt.PREFIX) {
+                } else if (relation == Text.PREFIX) {
                     return new PrefixFilter(new Term(key,(String)value));
 //                } else if (relation == Cmp.EQUAL) {
 //                    return new TermsFilter(new Term(key+STR_SUFFIX,(String)value));

--- a/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
+++ b/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
@@ -304,8 +304,8 @@ public class LuceneIndex implements IndexProvider {
             } else if (value instanceof String) {
                 if (relation == Text.CONTAINS) {
                     return new TermsFilter(new Term(key,((String)value).toLowerCase()));
-//                } else if (relation == Txt.PREFIX) {
-//                    return new PrefixFilter(new Term(key+STR_SUFFIX,(String)value));
+                } else if (relation == Txt.PREFIX) {
+                    return new PrefixFilter(new Term(key,(String)value));
 //                } else if (relation == Cmp.EQUAL) {
 //                    return new TermsFilter(new Term(key+STR_SUFFIX,(String)value));
 //                } else if (relation == Cmp.NOT_EQUAL) {
@@ -351,7 +351,7 @@ public class LuceneIndex implements IndexProvider {
         } else if (dataType == Geoshape.class) {
             return relation== Geo.WITHIN;
         } else if (dataType == String.class) {
-            return relation == Text.CONTAINS; // || relation == Txt.PREFIX || relation == Cmp.EQUAL || relation == Cmp.NOT_EQUAL;
+            return relation == Text.CONTAINS || relation == Text.PREFIX ; // || relation == Cmp.EQUAL || relation == Cmp.NOT_EQUAL;
         } else return false;
     }
 

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
@@ -44,7 +44,7 @@ public class LuceneIndexTest extends IndexProviderTest {
         assertFalse(index.supports(Exception.class));
 
         assertTrue(index.supports(String.class, Text.CONTAINS));
-		assertTrue(index.supports(String.class, Text.PREFIX));
+        assertTrue(index.supports(String.class, Text.PREFIX));
         assertTrue(index.supports(Double.class, Cmp.EQUAL));
         assertTrue(index.supports(Double.class, Cmp.GREATER_THAN_EQUAL));
         assertTrue(index.supports(Double.class, Cmp.LESS_THAN));

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
@@ -44,13 +44,13 @@ public class LuceneIndexTest extends IndexProviderTest {
         assertFalse(index.supports(Exception.class));
 
         assertTrue(index.supports(String.class, Text.CONTAINS));
+		assertTrue(index.supports(String.class, Text.PREFIX));
         assertTrue(index.supports(Double.class, Cmp.EQUAL));
         assertTrue(index.supports(Double.class, Cmp.GREATER_THAN_EQUAL));
         assertTrue(index.supports(Double.class, Cmp.LESS_THAN));
         assertTrue(index.supports(Long.class, Cmp.INTERVAL));
         assertTrue(index.supports(Geoshape.class, Geo.WITHIN));
 
-        assertFalse(index.supports(String.class, Text.PREFIX));
         assertFalse(index.supports(Double.class, Geo.INTERSECT));
         assertFalse(index.supports(Long.class, Text.CONTAINS));
         assertFalse(index.supports(Geoshape.class, Geo.DISJOINT));


### PR DESCRIPTION
Used already to list all of the artifacts in an Ivy repository represented in Titan that have names that begin with "comm".  This is being used on a web front end to link a textbox autocompletion mechanism to a specific property on vertices in a Titan graph.

![image](https://f.cloud.github.com/assets/1697736/706282/fa2870fc-dde9-11e2-9061-cbfe0e6c5634.png)
