### PR TITLE
add HBase and LockKeyColumnValueStoreTest improvements

### DIFF
--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
@@ -270,8 +270,6 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
             }
         } catch (ConnectionException e) {
             throw new PermanentStorageException(e);
-        } finally {
-            close();
         }
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryKeyColumnValueStore.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryKeyColumnValueStore.java
@@ -111,6 +111,10 @@ public class InMemoryKeyColumnValueStore implements KeyColumnValueStore {
         return name;
     }
 
+    public void clear() {
+        kcv.clear();
+    }
+
     @Override
     public void close() throws StorageException {
         kcv.clear();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
@@ -60,7 +60,9 @@ public class InMemoryStoreManager implements KeyColumnValueStoreManager {
 
     @Override
     public void clearStorage() throws StorageException {
-        close();
+        for (InMemoryKeyColumnValueStore store : stores.values()) {
+            store.clear();
+        }
     }
 
     @Override

--- a/titan-hbase/bin/hbase-daemon.sh
+++ b/titan-hbase/bin/hbase-daemon.sh
@@ -89,6 +89,12 @@ wait_until_done ()
     return 0
 }
 
+export HBASE_HEAPSIZE=4096
+export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
+export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
+export HBASE_USE_GC_LOGFILE=true
+export HBASE_MANAGES_ZK=true
+
 # get log directory
 if [ "$HBASE_LOG_DIR" = "" ]; then
   export HBASE_LOG_DIR="$HBASE_HOME/logs"

--- a/titan-hbase/config/hbase-env.sh
+++ b/titan-hbase/config/hbase-env.sh
@@ -28,7 +28,7 @@
 export HBASE_CLASSPATH=$HBASE_CLASSPATH:./target/test-lib
 
 # The maximum amount of heap to use, in MB. Default is 1000.
-# export HBASE_HEAPSIZE=1000
+export HBASE_HEAPSIZE=4096
 
 # Extra Java runtime options.
 # Below are what we set by default.  May only work with SUN JVM.
@@ -37,11 +37,10 @@ export HBASE_CLASSPATH=$HBASE_CLASSPATH:./target/test-lib
 export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
 
 # Uncomment below to enable java garbage collection logging in the .out file.
-# export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS" 
+export HBASE_OPTS="$HBASE_OPTS -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps $HBASE_GC_OPTS"
 
 # Uncomment below (along with above GC logging) to put GC information in its own logfile (will set HBASE_GC_OPTS)
-# export HBASE_USE_GC_LOGFILE=true
-
+export HBASE_USE_GC_LOGFILE=true
 
 # Uncomment below if you intend to use the EXPERIMENTAL off heap cache.
 # export HBASE_OPTS="$HBASE_OPTS -XX:MaxDirectMemorySize="
@@ -91,4 +90,4 @@ export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
 # export HBASE_SLAVE_SLEEP=0.1
 
 # Tell HBase whether it should manage it's own instance of Zookeeper or not.
-# export HBASE_MANAGES_ZK=true
+export HBASE_MANAGES_ZK=true

--- a/titan-hbase/config/hbase-site.xml
+++ b/titan-hbase/config/hbase-site.xml
@@ -22,16 +22,20 @@
  */
 -->
 <configuration>
-  <property>
-  <name>hbase.rootdir</name>
-  <value>file:///tmp/hbase</value>
-  </property>
-  <property>
-  <name>hbase.zookeeper.property.dataDir</name>
-  <value>/tmp/zookeeper</value>
-</property>
-<!--<property>
-  <name>hbase.master</name>
-  <value>local</value>
-</property>-->
+    <property>
+        <name>hbase.rootdir</name>
+        <value>file:///tmp/hbase</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.property.dataDir</name>
+        <value>/tmp/zookeeper</value>
+    </property>
+    <property>
+        <name>zookeeper.session.timeout</name>
+        <value>1200000</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.property.tickTime</name>
+        <value>6000</value>
+    </property>
 </configuration>

--- a/titan-hbase/pom.xml
+++ b/titan-hbase/pom.xml
@@ -107,7 +107,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.1</version>
                 <configuration>
-                    <argLine>-Xms256m -Xmx756m</argLine>
+                    <argLine>-Xms256m -Xmx1024m</argLine>
                     <excludes>
                         <!-- Excluded because these take too long to run and require a lot of memory - see comprehensive profile -->
                         <exclude>**/*PerformanceTest.java</exclude>

--- a/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseLockKeyColumnValueStoreTest.java
+++ b/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseLockKeyColumnValueStoreTest.java
@@ -16,7 +16,6 @@ public class HBaseLockKeyColumnValueStoreTest extends LockKeyColumnValueStoreTes
     }
 
     public KeyColumnValueStoreManager openStorageManager(int idx) throws StorageException {
-        Configuration sc = HBaseStorageSetup.getHBaseStorageConfiguration();
-        return new HBaseStoreManager(sc);
+        return new HBaseStoreManager(HBaseStorageSetup.getHBaseStorageConfiguration());
     }
 }

--- a/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseMultiWriteKeyColumnValueStoreTest.java
+++ b/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseMultiWriteKeyColumnValueStoreTest.java
@@ -20,7 +20,6 @@ public class HBaseMultiWriteKeyColumnValueStoreTest extends MultiWriteKeyColumnV
     }
 
     private Configuration getConfig() {
-        Configuration c = HBaseStorageSetup.getHBaseStorageConfiguration();
-        return c;
+        return HBaseStorageSetup.getHBaseStorageConfiguration();
     }
 }


### PR DESCRIPTION
Cuts down time taken by HBase LockStore test to 8 minutes instead of 17 (2x improvement) and other tests to be slightly faster, also makes all other tests extending LockKeyColumnValueStoreTest run faster.
