### PR TITLE
Fix bin/* helper scripts

### DIFF
--- a/titan-all/pom.xml
+++ b/titan-all/pom.xml
@@ -64,6 +64,36 @@
         <plugins>
             <!-- Disable unnecessary plugins -->
             <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <attach>false</attach>
+                    <descriptors>
+                        <descriptor>src/assembly/standalone.xml</descriptor>
+                        <descriptor>src/assembly/distribution.xml</descriptor>
+                    </descriptors>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
+                    <outputDirectory>target</outputDirectory>
+                    <workDirectory>target/assembly/work</workDirectory>
+                    <tarLongFileMode>warn</tarLongFileMode>
+                    <archiverConfig>
+                        <fileMode>420</fileMode>
+                        <!-- 420(dec) = 644(oct) -->
+                        <directoryMode>493</directoryMode>
+                        <!-- 493(dec) = 755(oct) -->
+                        <defaultDirectoryMode>493</defaultDirectoryMode>
+                    </archiverConfig>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
Commit 834c5649a147edd2bfdd0d382eba9b0160526131 accidentally remove the ability to run the shell script drivers like bin/gremlin.sh. This patch restores that ability.
