### PR TITLE
Add explicit elasticsearch mappings for strings/ints/etc

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanType.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanType.java
@@ -48,8 +48,8 @@ public interface TitanType extends TitanVertex {
      * <i>Birthdate</i> is an example of an out-unique property key since each person has at most one birth date.</li>
      * <li>A property key is in-unique, if at most one vertex can be assigned a given value.
      * <i>Social security number</i> is an example of an in-unique property key since there can only be one person for a particular SSN.</li>
-     * <li>An edge lable is out-unique, if a vertex has at most one outgoing edge for that label.
-     * <i>Father</i> is an exmaple of a functional edge label, since each person has at most one father.</li>
+     * <li>An edge label is out-unique, if a vertex has at most one outgoing edge for that label.
+     * <i>Father</i> is an example of a functional edge label, since each person has at most one father.</li>
      * </ul>
      *
      * @return true, if the type is unique in the given direction, else false

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TypeMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TypeMaker.java
@@ -56,7 +56,7 @@ public interface TypeMaker {
      *
      * <p />
      * The consistency parameter specifies the consistency guarantees given when ensuring uniqueness. Without acquiring locks,
-     * unique relations may be overwritten by competing transactions. Acquring locks prohibits that at and additional "locking cost".
+     * unique relations may be overwritten by competing transactions. Acquiring locks prohibits that at an additional "locking cost".
      *
      * @return this type maker
      */
@@ -136,7 +136,7 @@ public interface TypeMaker {
      * For instance, if all edges with label <i>friend</i> have a property with key <i>createdOn</i>, then specifying
      * (<i>createdOn</i>) as the signature for type <i>friend</i> allows friend edges to be stored more efficiently.
      * <br />
-     * {@link TitanType}s used in the primary key must be either property out-unique keys or out-unique unidirected edge lables.
+     * {@link TitanType}s used in the primary key must be either property out-unique keys or out-unique unidirected edge labels.
      * <br />
      * The signature should not contain any types already included in the primary key. The primary key provides the same
      * storage and retrieval efficiency.

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanGraphQueryBuilder.java
@@ -118,7 +118,7 @@ public class TitanGraphQueryBuilder implements TitanGraphQuery, QueryOptimizer<S
 
 
     @Override
-    public TitanGraphQueryBuilder limit(long max) {
+    public TitanGraphQuery limit(long max) {
         Preconditions.checkArgument(max>=0,"Non-negative limit expected: %s",max);
         Preconditions.checkArgument(max<=Integer.MAX_VALUE,"Limit expected to be smaller or equal than [%s] but given %s",Integer.MAX_VALUE,limit);
         this.limit=(int)max;

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -168,30 +169,55 @@ public class ElasticSearchIndex implements IndexProvider {
 
     @Override
     public void register(String store, String key, Class<?> dataType, TransactionHandle tx) throws StorageException {
-        if (dataType==Geoshape.class) { //Only need to update for geoshape
-            log.debug("Registering geo_point type for {}",key);
-            XContentBuilder mapping = null;
-            try {
-                mapping =
-                    XContentFactory.jsonBuilder()
-                            .startObject()
-                                .startObject(store)
-                                    .startObject("properties")
-                                        .startObject(key)
-                                            .field("type", "geo_point")
-                                        .endObject()
-                                    .endObject()
-                                .endObject()
-                            .endObject();
-            } catch (IOException e) {
-                throw new PermanentStorageException("Could not render json for put mapping request",e);
+        XContentBuilder mapping = null;
+
+        try {
+            mapping = XContentFactory.jsonBuilder().
+                    startObject().
+                        startObject(store).
+                            startObject("properties").
+                                startObject(key);
+
+            if (dataType==String.class) {
+                log.debug("Registering string type for {}",key);
+                mapping.field("type", "string");
+            } else if (dataType==Float.class) {
+                log.debug("Registering float type for {}",key);
+                mapping.field("type", "float");
+            } else if (dataType==Double.class) {
+                log.debug("Registering double type for {}",key);
+                mapping.field("type", "double");
+            } else if (dataType==Byte.class) {
+                log.debug("Registering byte type for {}",key);
+                mapping.field("type", "byte");
+            } else if (dataType==Short.class) {
+                log.debug("Registering short type for {}",key);
+                mapping.field("type", "short");
+            } else if (dataType==Integer.class) {
+                log.debug("Registering integer type for {}",key);
+                mapping.field("type", "integer");
+            } else if (dataType==Long.class) {
+                log.debug("Registering long type for {}",key);
+                mapping.field("type", "long");
+            } else if (dataType==Boolean.class) {
+                log.debug("Registering boolean type for {}",key);
+                mapping.field("type", "boolean");
+            } else if (dataType==Geoshape.class) {
+                log.debug("Registering geo_point type for {}",key);
+                mapping.field("type", "geo_point");
             }
-            try {
-                PutMappingResponse response = client.admin().indices().preparePutMapping(indexName).
-                    setIgnoreConflicts(false).setType(store).setSource(mapping).execute().actionGet();
-            } catch (Exception e) {
-                throw convert(e);
-            }
+
+            mapping.endObject().endObject().endObject().endObject();
+
+        } catch (IOException e) {
+            throw new PermanentStorageException("Could not render json for put mapping request",e);
+        }
+
+        try {
+            PutMappingResponse response = client.admin().indices().preparePutMapping(indexName).
+                setIgnoreConflicts(false).setType(store).setSource(mapping).execute().actionGet();
+        } catch (Exception e) {
+            throw convert(e);
         }
     }
 

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -379,6 +379,7 @@ public class ElasticSearchIndex implements IndexProvider {
         srb.setQuery(QueryBuilders.matchAllQuery());
         srb.setFilter(getFilter(query.getCondition()));
         srb.setFrom(0);
+        srb.setNoFields();
         if (query.hasLimit()) srb.setSize(query.getLimit());
         else srb.setSize(MAX_RESULT_SET_SIZE);
         //srb.setExplain(true);

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -191,7 +191,7 @@ public class ElasticSearchIndex implements IndexProvider {
                 throw new PermanentStorageException("Could not render json for put mapping request",e);
             }
             try {
-            PutMappingResponse response = client.admin().indices().preparePutMapping(indexName).
+                PutMappingResponse response = client.admin().indices().preparePutMapping(indexName).
                     setIgnoreConflicts(false).setType(store).setSource(mapping).execute().actionGet();
             } catch (Exception e) {
                 throw convert(e);

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
@@ -40,9 +40,12 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
     @Test
     public void testSupport() {
         assertTrue(index.supports(String.class));
+        assertTrue(index.supports(Float.class));
         assertTrue(index.supports(Double.class));
-        assertTrue(index.supports(Long.class));
+        assertTrue(index.supports(Byte.class));
+        assertTrue(index.supports(Short.class));
         assertTrue(index.supports(Integer.class));
+        assertTrue(index.supports(Long.class));
         assertTrue(index.supports(Geoshape.class));
         assertFalse(index.supports(Object.class));
         assertFalse(index.supports(Exception.class));


### PR DESCRIPTION
titan-es takes advantage of Elasticsearch's default behavior to automatically create indices new field. However, this  [functionality can be disabled](http://www.elasticsearch.org/guide/reference/api/index_/) by `index.mapper.dynamic: false` in `elasticsearch.yml`. Disabling this feature would then break Titan's ability to index various types. This pull request avoids that problem by explicitly creating field mappings for String/Float/Double/Byte/Short/Integer/Long/Boolean types. The before/after is demonstrated in this [gist](https://gist.github.com/erickt/6442316).

This also includes a patch to stop titan-es from fetching the stored fields from elasticsearch which should make doing an Elasticsearch query much more efficient when dealing with a large elasticsearch index.

Finally, it includes some other minor cleanup commits as well.
