### PR TITLE
Elasticsearch/Lucene should index fields by their actual name

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexTransaction.java
@@ -32,26 +32,26 @@ public class IndexTransaction implements TransactionHandle {
         this.mutations = null;
     }
 
-    public void add(String store, String docid, String key, Object value, boolean isNew) {
-        getIndexMutation(store,docid,isNew,false).addition(new IndexEntry(key,value));
+    public void add(String storeName, String docId, String key, Object value, boolean isNew) {
+        getIndexMutation(storeName,docId,isNew,false).addition(new IndexEntry(key,value));
     }
 
-    public void delete(String store, String docid, String key, boolean deleteAll) {
-        getIndexMutation(store,docid,false,deleteAll).deletion(key);
+    public void delete(String storeName, String docId, String key, boolean deleteAll) {
+        getIndexMutation(storeName,docId,false,deleteAll).deletion(key);
     }
 
-    private IndexMutation getIndexMutation(String store, String docid, boolean isNew, boolean isDeleted) {
+    private IndexMutation getIndexMutation(String storeName, String docId, boolean isNew, boolean isDeleted) {
         if (mutations==null) mutations = new HashMap<String,Map<String,IndexMutation>>(DEFAULT_OUTER_MAP_SIZE);
-        Map<String,IndexMutation> storeMutations = mutations.get(store);
+        Map<String,IndexMutation> storeMutations = mutations.get(storeName);
         if (storeMutations==null) {
             storeMutations = new HashMap<String,IndexMutation>(DEFAULT_INNER_MAP_SIZE);
-            mutations.put(store,storeMutations);
+            mutations.put(storeName,storeMutations);
 
         }
-        IndexMutation m = storeMutations.get(docid);
+        IndexMutation m = storeMutations.get(docId);
         if (m==null) {
             m = new IndexMutation(isNew,isDeleted);
-            storeMutations.put(docid, m);
+            storeMutations.put(docId, m);
         }
         return m;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/IndexSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/IndexSerializer.java
@@ -69,11 +69,11 @@ public class IndexSerializer {
     public void newPropertyKey(TitanKey key, BackendTransaction tx) throws StorageException {
         for (String index : key.getIndexes(Vertex.class)) {
             if (!index.equals(Titan.Token.STANDARD_INDEX))
-                tx.getIndexTransactionHandle(index).register(ElementType.VERTEX.getName(),key2String(key),key.getDataType());
+                tx.getIndexTransactionHandle(index).register(ElementType.VERTEX.getName(),key.getName(),key.getDataType());
         }
         for (String index : key.getIndexes(Edge.class)) {
             if (!index.equals(Titan.Token.STANDARD_INDEX))
-                tx.getIndexTransactionHandle(index).register(ElementType.EDGE.getName(),key2String(key),key.getDataType());
+                tx.getIndexTransactionHandle(index).register(ElementType.EDGE.getName(),key.getName(),key.getDataType());
         }
     }
 
@@ -163,12 +163,12 @@ public class IndexSerializer {
 
     private void addKeyValue(TitanElement element, TitanKey key, Object value, String index, BackendTransaction tx) throws StorageException {
         Preconditions.checkArgument(key.isUnique(Direction.OUT),"Only out-unique properties are supported by index [%s]",index);
-        tx.getIndexTransactionHandle(index).add(getStoreName(element),element2String(element),key2String(key),value,element.isNew());
+        tx.getIndexTransactionHandle(index).add(getStoreName(element),element2String(element),key.getName(),value,element.isNew());
     }
 
     private void removeKeyValue(TitanElement element, TitanKey key, String index, BackendTransaction tx) {
         Preconditions.checkArgument(key.isUnique(Direction.OUT), "Only out-unique properties are supported by index [%s]", index);
-        tx.getIndexTransactionHandle(index).delete(getStoreName(element),element2String(element),key2String(key),element.isRemoved());
+        tx.getIndexTransactionHandle(index).delete(getStoreName(element),element2String(element),key.getName(),element.isRemoved());
     }
 
     /* ################################################
@@ -282,13 +282,12 @@ public class IndexSerializer {
                         TitanKey key = (TitanKey) pc.getKey();
                         Preconditions.checkArgument(key.hasIndex(indexName, resultType.getElementType()));
                         Preconditions.checkArgument(indexes.get(indexName).supports(key.getDataType(), pc.getPredicate()));
-                        return new PredicateCondition<String, TitanElement>(key2String(key), pc.getPredicate(), pc.getValue());
+                        return new PredicateCondition<String, TitanElement>(key.getName(), pc.getPredicate(), pc.getValue());
                     }
                 }));
             }
         }
     }
-
 
     /* ################################################
                 Utility Functions
@@ -319,10 +318,6 @@ public class IndexSerializer {
     private static final Object string2ElementId(String str) {
         if (str.contains(RelationIdentifier.TOSTRING_DELIMITER)) return RelationIdentifier.parse(str);
         else return name2LongID(str);
-    }
-
-    private static final String key2String(TitanKey key) {
-        return longID2Name(key.getID());
     }
 
     private static final String longID2Name(long id) {


### PR DESCRIPTION
This pull request makes a backwards incompatible change to make Titan index fields by their proper `String` field name. Before this pull request, Titan instead indexed fields by an internal unique `Long` identifier, which makes it difficult to directly access Elasticsearch to perform queries that are not general purpose enough to be exposed through the Titan API.

An alternative to this approach would be to directly expose discovering the `Long` identifier for the fields, and then an end user could handle converting a string field name to and from that identifier, but I feel that would be pretty painful for the user. Another way would be to expose a "raw query" API, but I feel it would be difficult to make a generic interface. It would be ultimately easier to just to get a reference to the underlying index and query directly against that. I plan to implement this in a later pull request.

There are two main downsides to this approach. First, is that this will force users of Titan 0.3.x to reindex their graphs. Second, there _may_ be some overhead by storing the full string instead of an encoded integer, but lucene is pretty efficient about storing documents, so I don't think it will add a significant overhead to Titan's indexing support.

For more details, you can refer to this [gist](https://gist.github.com/erickt/6444959) to show the benefits of this change.

Finally, this pull request does also include some minor code cleanup.
