### PR TITLE
Setting cassandra transaction timestamp

### DIFF
--- a/titan-berkeleyje/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
+++ b/titan-berkeleyje/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
@@ -83,6 +83,13 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
         return features;
     }
 
+    // This implementation ignores timestamp (present for interface compatibility)
+    @Override
+    public BerkeleyJETx beginTransaction(ConsistencyLevel level, Long timestamp)
+            throws StorageException {
+        return beginTransaction(level);
+    }
+
     @Override
     public BerkeleyJETx beginTransaction(ConsistencyLevel level) throws StorageException {
         try {

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
@@ -124,7 +124,15 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
 
     @Override
     public StoreTransaction beginTransaction(ConsistencyLevel level) {
-        return new CassandraTransaction(level, readConsistencyLevel, writeConsistencyLevel);
+        return beginTransaction(level, null);
+    }
+
+    @Override
+    public StoreTransaction beginTransaction(ConsistencyLevel level, Long timestamp) {
+        CassandraTransaction transaction = new CassandraTransaction(level, readConsistencyLevel,
+                                                                    writeConsistencyLevel,
+                                                                    timestamp);
+        return transaction;
     }
 
     @Override

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraTransaction.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraTransaction.java
@@ -14,6 +14,7 @@ import com.thinkaurelius.titan.diskstorage.keycolumnvalue.StoreTransaction;
  * @author Dan LaRocque <dalaro@hopcount.org>
  */
 public class CassandraTransaction extends AbstractStoreTransaction {
+    private final Long timestamp;
 
     public enum Consistency {
         ONE, TWO, THREE, ANY, ALL, QUORUM, LOCAL_QUORUM, EACH_QUORUM;
@@ -71,7 +72,8 @@ public class CassandraTransaction extends AbstractStoreTransaction {
     private final Consistency readConsistency;
     private final Consistency writeConsistency;
 
-    public CassandraTransaction(ConsistencyLevel level, Consistency readConsistency, Consistency writeConsistency) {
+    public CassandraTransaction(ConsistencyLevel level, Consistency readConsistency,
+                                Consistency writeConsistency, Long timestamp) {
         super(level);
         if (level == ConsistencyLevel.KEY_CONSISTENT) {
             this.readConsistency = Consistency.QUORUM;
@@ -82,6 +84,18 @@ public class CassandraTransaction extends AbstractStoreTransaction {
             this.readConsistency = readConsistency;
             this.writeConsistency = writeConsistency;
         }
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Constructor setting transaction timestamp to null if not specified
+     * @param level
+     * @param readConsistency
+     * @param writeConsistency
+     */
+    public CassandraTransaction(ConsistencyLevel level, Consistency readConsistency,
+                                Consistency writeConsistency) {
+        this(level, readConsistency, writeConsistency, null);
     }
 
     public Consistency getReadConsistencyLevel() {
@@ -97,5 +111,11 @@ public class CassandraTransaction extends AbstractStoreTransaction {
         return (CassandraTransaction) txh;
     }
 
-
+    /**
+     * Returns transaction timestamp
+     * @return timestamp
+     */
+    public Long getTimestamp() {
+        return timestamp;
+    }
 }

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -48,6 +48,7 @@ import com.thinkaurelius.titan.diskstorage.StaticBuffer;
 import com.thinkaurelius.titan.diskstorage.StorageException;
 import com.thinkaurelius.titan.diskstorage.TemporaryStorageException;
 import com.thinkaurelius.titan.diskstorage.cassandra.AbstractCassandraStoreManager;
+import com.thinkaurelius.titan.diskstorage.cassandra.CassandraTransaction;
 import com.thinkaurelius.titan.diskstorage.cassandra.thrift.thriftpool.CTConnection;
 import com.thinkaurelius.titan.diskstorage.cassandra.thrift.thriftpool.CTConnectionFactory;
 import com.thinkaurelius.titan.diskstorage.cassandra.thrift.thriftpool.CTConnectionFactory.Config;
@@ -152,9 +153,21 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
     @Override
     public void mutateMany(Map<String, Map<StaticBuffer, KCVMutation>> mutations, StoreTransaction txh) throws StorageException {
         Preconditions.checkNotNull(mutations);
+        CassandraTransaction ctxh = getTx(txh);
 
-        long deletionTimestamp = TimeUtility.INSTANCE.getApproxNSSinceEpoch(false);
-        long additionTimestamp = TimeUtility.INSTANCE.getApproxNSSinceEpoch(true);
+        long deletionTimestamp;
+        long additionTimestamp;
+
+        if (ctxh.getTimestamp() == null) {
+            // If cassandra transaction timestamp not provided, use current time
+            deletionTimestamp = TimeUtility.INSTANCE.getApproxNSSinceEpoch(false);
+            additionTimestamp = TimeUtility.INSTANCE.getApproxNSSinceEpoch(true);
+        } else {
+            // Set the transaction timestamp according to transaction. Deletions get
+            // the earlier timestamp.
+            deletionTimestamp = ctxh.getTimestamp();
+            additionTimestamp = ctxh.getTimestamp() + 1;
+        }
 
         ConsistencyLevel consistency = getTx(txh).getWriteConsistencyLevel().getThriftConsistency();
 

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/AbstractCassandraGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/AbstractCassandraGraphTest.java
@@ -1,0 +1,101 @@
+package com.thinkaurelius.titan.graphdb;
+
+import com.google.common.collect.Iterables;
+
+import com.thinkaurelius.titan.core.TitanTransaction;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
+import com.tinkerpop.blueprints.Vertex;
+
+import org.apache.commons.configuration.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public abstract class AbstractCassandraGraphTest extends TitanGraphTest {
+
+    public AbstractCassandraGraphTest(Configuration config) {
+        super(config);
+    }
+
+    @Test
+    public void testSetTimestamp() {
+        // Transaction 1: Init graph with two vertices, having set "name" and "age" properties
+        TitanTransaction tx1 = graph.newTransaction(100);
+        String name = "name";
+        String age = "age";
+        String address = "address";
+
+        Vertex v1 = tx1.addVertex();
+        Vertex v2 = tx1.addVertex();
+        v1.setProperty(name, "a");
+        v2.setProperty(age, "14");
+        v2.setProperty(name, "b");
+        v2.setProperty(age, "42");
+        tx1.commit();
+
+        // Fetch vertex ids
+        Object id1 = v1.getId();
+        Object id2 = v2.getId();
+
+        // Transaction 2: Remove "name" property from v1, set "address" property; create
+        // an edge v2 -> v1
+        TitanTransaction tx2 = graph.newTransaction(1000);
+        v1 = tx2.getVertex(id1);
+        v2 = tx2.getVertex(id2);
+        v1.removeProperty(name);
+        v1.setProperty(address, "xyz");
+        Edge edge = tx2.addEdge(1, v2, v1, "parent");
+        tx2.commit();
+        Object edgeId = edge.getId();
+
+        Vertex afterTx2 = graph.getVertex(id1);
+
+        // Verify that "name" property is gone
+        Assert.assertFalse(afterTx2.getPropertyKeys().contains(name));
+        // Verify that "address" property is set
+        Assert.assertEquals("xyz", afterTx2.getProperty(address));
+        // Verify that the edge is properly registered with the endpoint vertex
+        Assert.assertEquals(1, Iterables.size(afterTx2.getEdges(Direction.IN, "parent")));
+        // Verify that edge is registered under the id
+        Assert.assertNotNull(graph.getEdge(edgeId));
+        graph.commit();
+
+        // Transaction 3: Remove "address" property from v1 with earlier timestamp than
+        // when the value was set
+        TitanTransaction tx3 = graph.newTransaction(200);
+        v1 = tx3.getVertex(id1);
+        v1.removeProperty(address);
+        tx3.commit();
+
+        Vertex afterTx3 = graph.getVertex(id1);
+        graph.commit();
+        // Verify that "address" is still set
+        Assert.assertEquals("xyz", afterTx3.getProperty(address));
+
+        // Transaction 4: Modify "age" property on v2, remove edge between v2 and v1
+        TitanTransaction tx4 = graph.newTransaction(2000);
+        v2 = tx4.getVertex(id2);
+        v2.setProperty(age, "15");
+        tx4.removeEdge(tx4.getEdge(edgeId));
+        tx4.commit();
+
+        Vertex afterTx4 = graph.getVertex(id2);
+        // Verify that "age" property is modified
+        Assert.assertEquals("15", afterTx4.getProperty(age));
+        // Verify that edge is no longer registered with the endpoint vertex
+        Assert.assertEquals(0, Iterables.size(afterTx4.getEdges(Direction.OUT, "parent")));
+        // Verify that edge entry disappeared from id registry
+        Assert.assertNull(graph.getEdge(edgeId));
+
+        // Transaction 5: Modify "age" property on v2 with earlier timestamp
+        TitanTransaction tx5 = graph.newTransaction(1500);
+        v2 = tx5.getVertex(id2);
+        v2.setProperty(age, "16");
+        tx5.commit();
+        Vertex afterTx5 = graph.getVertex(id2);
+
+        // Verify that the property value is unchanged
+        Assert.assertEquals("15", afterTx5.getProperty(age));
+
+    }
+}

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/ExternalAstyanaxGraphTest.java
@@ -2,11 +2,11 @@ package com.thinkaurelius.titan.graphdb.astyanax;
 
 import com.thinkaurelius.titan.CassandraStorageSetup;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
+import com.thinkaurelius.titan.graphdb.AbstractCassandraGraphTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-public class ExternalAstyanaxGraphTest extends TitanGraphTest {
+public class ExternalAstyanaxGraphTest extends AbstractCassandraGraphTest {
 
     public ExternalAstyanaxGraphTest() {
         super(CassandraStorageSetup.getAstyanaxGraphConfiguration(ExternalAstyanaxGraphTest.class.getSimpleName()));

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/InternalAstyanaxGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/astyanax/InternalAstyanaxGraphTest.java
@@ -2,14 +2,14 @@ package com.thinkaurelius.titan.graphdb.astyanax;
 
 import com.thinkaurelius.titan.CassandraStorageSetup;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
+import com.thinkaurelius.titan.graphdb.AbstractCassandraGraphTest;
 import com.thinkaurelius.titan.testcategory.RandomPartitionerTests;
 
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category({RandomPartitionerTests.class})
-public class InternalAstyanaxGraphTest extends TitanGraphTest {
+public class InternalAstyanaxGraphTest extends AbstractCassandraGraphTest {
 
     @BeforeClass
     public static void startCassandra() {

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/embedded/InternalCassandraEmbeddedGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/embedded/InternalCassandraEmbeddedGraphTest.java
@@ -3,11 +3,11 @@ package com.thinkaurelius.titan.graphdb.embedded;
 import org.junit.experimental.categories.Category;
 
 import com.thinkaurelius.titan.CassandraStorageSetup;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
+import com.thinkaurelius.titan.graphdb.AbstractCassandraGraphTest;
 import com.thinkaurelius.titan.testcategory.ByteOrderedPartitionerTests;
 
 @Category({ByteOrderedPartitionerTests.class})
-public class InternalCassandraEmbeddedGraphTest extends TitanGraphTest {
+public class InternalCassandraEmbeddedGraphTest extends AbstractCassandraGraphTest {
 
     public InternalCassandraEmbeddedGraphTest() {
         super(CassandraStorageSetup.getEmbeddedCassandraPartitionGraphConfiguration(InternalCassandraEmbeddedGraphTest.class.getSimpleName()));

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ExternalCassandraGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ExternalCassandraGraphTest.java
@@ -2,11 +2,11 @@ package com.thinkaurelius.titan.graphdb.thrift;
 
 import com.thinkaurelius.titan.CassandraStorageSetup;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
+import com.thinkaurelius.titan.graphdb.AbstractCassandraGraphTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-public class ExternalCassandraGraphTest extends TitanGraphTest {
+public class ExternalCassandraGraphTest extends AbstractCassandraGraphTest {
 
     public static CassandraProcessStarter ch = new CassandraProcessStarter();
 

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/InternalCassandraGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/InternalCassandraGraphTest.java
@@ -2,14 +2,14 @@ package com.thinkaurelius.titan.graphdb.thrift;
 
 import com.thinkaurelius.titan.CassandraStorageSetup;
 import com.thinkaurelius.titan.diskstorage.cassandra.CassandraProcessStarter;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
+import com.thinkaurelius.titan.graphdb.AbstractCassandraGraphTest;
 import com.thinkaurelius.titan.testcategory.RandomPartitionerTests;
 
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 @Category({RandomPartitionerTests.class})
-public class InternalCassandraGraphTest extends TitanGraphTest {
+public class InternalCassandraGraphTest extends AbstractCassandraGraphTest {
 
     public InternalCassandraGraphTest() {
         super(CassandraStorageSetup.getCassandraThriftGraphConfiguration(InternalCassandraGraphTest.class.getSimpleName()));

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
@@ -379,13 +379,24 @@ public class Backend {
     //3. Messaging queues
 
     /**
-     * Opens a new transaction against all registered backend system wrapped in one {@link BackendTransaction}.
-     *
-     * @return
+     * Opens a new transaction without set timestamp against all registered backend system
+     * wrapped in one {@link BackendTransaction}.
+     * @return BackendTransaction
      * @throws StorageException
      */
     public BackendTransaction beginTransaction() throws StorageException {
-        StoreTransaction tx = storeManager.beginTransaction(ConsistencyLevel.DEFAULT);
+        return beginTransaction(null);
+    }
+
+    /**
+     * Opens a new transaction with set timestamp against all registered backend system
+     * wrapped in one {@link BackendTransaction}.
+     *
+     * @return BackendTransaction
+     * @throws StorageException
+     */
+    public BackendTransaction beginTransaction(Long timestamp) throws StorageException {
+        StoreTransaction tx = storeManager.beginTransaction(ConsistencyLevel.DEFAULT, timestamp);
         if (bufferSize > 1) {
             assert storeManager.getFeatures().supportsBatchMutation();
             tx = new BufferTransaction(tx, storeManager, bufferSize, writeAttempts, persistAttemptWaittime);
@@ -394,7 +405,9 @@ public class Backend {
             if (storeFeatures.supportsTransactions()) {
                 //No transaction wrapping needed
             } else if (storeFeatures.supportsConsistentKeyOperations()) {
-                tx = new ExpectedValueCheckingTransaction(tx, storeManager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT), readAttempts);
+                tx = new ExpectedValueCheckingTransaction(
+                    tx,  storeManager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT, timestamp),
+                                                       readAttempts);
             }
         }
 
@@ -525,7 +538,7 @@ public class Backend {
             }
         }
     }
-    
+
 //
 //    public synchronized static final void registerStorageManager(String name, Class<? extends StoreManager> clazz) {
 //        Preconditions.checkNotNull(name);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/idmanagement/ConsistentKeyIDManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/idmanagement/ConsistentKeyIDManager.java
@@ -55,7 +55,7 @@ public class ConsistentKeyIDManager extends AbstractIDManager {
         for (int retry = 0; retry < idApplicationRetryCount; retry++) {
             StoreTransaction txh = null;
             try {
-                txh = manager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT);
+                txh = manager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT, null);
                 long nextID = getCurrentID(getPartitionKey(partition), txh);
                 txh.commit();
                 return nextID;
@@ -102,7 +102,7 @@ public class ConsistentKeyIDManager extends AbstractIDManager {
         for (int retry = 0; retry < idApplicationRetryCount; retry++) {
             StoreTransaction txh = null;
             try {
-                txh = manager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT);
+                txh = manager.beginTransaction(ConsistencyLevel.KEY_CONSISTENT, null);
                 // Read the latest counter values from the idStore
                 StaticBuffer partitionKey = getPartitionKey(partition);
                 // calculate the start (inclusive) and end (exclusive) of the allocation we're about to attempt

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StoreManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StoreManager.java
@@ -11,11 +11,22 @@ import com.thinkaurelius.titan.diskstorage.StorageException;
 public interface StoreManager {
 
     /**
-     * Returns a transaction handle for a new transaction.
-     *
+     * Returns a transaction handle for a new transaction without set timestamp.
+     * @param consistencyLevel
      * @return New Transaction Handle
+     * @throws StorageException
      */
     public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel) throws StorageException;
+
+    /**
+     * Returns a transaction handle for a new transaction with set timestamp.
+     * @param consistencyLevel
+     * @param timestamp pre-defined timestamp for the newly created transaction
+     * @return New Transaction Handle
+     * @throws StorageException
+     */
+    public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel, Long timestamp)
+        throws StorageException;
 
     /**
      * Closes the Storage Manager and all databases that have been opened.

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
@@ -45,6 +45,13 @@ public class InMemoryStoreManager implements KeyColumnValueStoreManager {
         features.hasLocalKeyPartition = false;
     }
 
+    // This implementation ignores timestamp (present for interface compatibility)
+    @Override
+    public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel, Long timestamp)
+            throws StorageException {
+        return beginTransaction(consistencyLevel);
+    }
+
     @Override
     public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel) throws StorageException {
         return new TransactionHandle(consistencyLevel);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreManagerAdapter.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/keyvalue/OrderedKeyValueStoreManagerAdapter.java
@@ -42,6 +42,13 @@ public class OrderedKeyValueStoreManagerAdapter implements KeyColumnValueStoreMa
         return manager.getFeatures();
     }
 
+    // This implementation ignores timestamp (present for interface compatibility)
+    @Override
+    public StoreTransaction beginTransaction(ConsistencyLevel level, Long timestamp)
+            throws StorageException {
+        return beginTransaction(level);
+    }
+
     @Override
     public StoreTransaction beginTransaction(ConsistencyLevel level) throws StorageException {
         return manager.beginTransaction(level);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/StandardTitanGraph.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/StandardTitanGraph.java
@@ -104,18 +104,42 @@ public class StandardTitanGraph extends TitanBlueprintsGraph {
 
     @Override
     public TitanTransaction newTransaction() {
-        return newTransaction(new TransactionConfig(config, false));
+        return newTransaction(new TransactionConfig(config, false), null);
     }
 
     @Override
     public TitanTransaction newThreadBoundTransaction() {
-        return newTransaction(new TransactionConfig(config, true));
+        return newTransaction(new TransactionConfig(config, true), null);
     }
 
+    /**
+     * Creates a new transaction with set timestamp and provided db configuration
+     * @param timestamp
+     * @return standard titan transaction
+     */
+    public StandardTitanTx newTransaction(long timestamp) {
+        return newTransaction(new TransactionConfig(config, false), timestamp);
+    }
+
+    /**
+     * Creates a new transaction with provided db config and null (default) timestamp
+     * @param configuration
+     * @return standard titan transaction
+     */
     public StandardTitanTx newTransaction(TransactionConfig configuration) {
+        return newTransaction(configuration, null);
+    }
+
+    /**
+     * Creates new transaction with provided transaction config and set timestamp
+     * @param configuration
+     * @param timestamp
+     * @return standard titan transaction
+     */
+    public StandardTitanTx newTransaction(TransactionConfig configuration, Long timestamp) {
         if (!isOpen) ExceptionFactory.graphShutdown();
         try {
-            return new StandardTitanTx(this, configuration, backend.beginTransaction());
+            return new StandardTitanTx(this, configuration, backend.beginTransaction(timestamp));
         } catch (StorageException e) {
             throw new TitanException("Could not start new transaction", e);
         }

--- a/titan-hbase/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
+++ b/titan-hbase/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
@@ -245,6 +245,13 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
         return new HBaseTransaction(level);
     }
 
+    //This implementation actually ignores timestamp (present for interface compatibility)
+    @Override
+    public StoreTransaction beginTransaction(ConsistencyLevel level, Long timestamp)
+            throws StorageException {
+        return beginTransaction(level);
+    }
+
 
     /**
      * Deletes the specified table with all its columns.

--- a/titan-persistit/src/main/java/com/thinkaurelius/titan/diskstorage/persistit/PersistitStoreManager.java
+++ b/titan-persistit/src/main/java/com/thinkaurelius/titan/diskstorage/persistit/PersistitStoreManager.java
@@ -129,6 +129,13 @@ public class PersistitStoreManager extends LocalStoreManager implements OrderedK
         }
     }
 
+    // This implementation ignores timestamp (present for interface compatibility)
+    @Override
+    public PersistitTransaction beginTransaction(ConsistencyLevel level, Long timestamp)
+            throws StorageException {
+        return beginTransaction(level);
+    }
+
     /**
      * Returns a transaction handle for a new transaction.
      *

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/inmemory/InMemoryStorageAdapter.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/inmemory/InMemoryStorageAdapter.java
@@ -86,6 +86,13 @@ public class InMemoryStorageAdapter implements KeyColumnValueStoreManager {
         //Do nothing
     }
 
+    // This implementation ignores timestamp (present for interface compatibility)
+    @Override
+    public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel, Long timestamp)
+            throws StorageException {
+        return beginTransaction(consistencyLevel);
+    }
+
     @Override
     public StoreTransaction beginTransaction(ConsistencyLevel consistencyLevel) throws StorageException {
         return new StoreTransaction() {


### PR DESCRIPTION
We would like to have the ability to pre-set timestamps on cassandra transactions, to manage modification ordering when updates are submitted by clients running in parallel.

I decided to implement a method ((StandardTitanGraph.newTransaction(timestamp) ) to open a timestamped transaction manually, if needed. This way, it does not interfere with transaction auto-starts, when updates are executed directly on a graph. Some extra care for managing the state of the transaction is needed, unlike the alternative approach, where it could have been set at graph.commit(timestamp). However, this way the intended functionality is at least possible, if not convenient. If the method provided here will turn out to be useful for a larger audience, the graph.commit(timestamp) functionality support can always be added.

I added a test (AbstractCassandraGraphTest) to be run against all Cassandra backends. Various operations with timestamps are submitted for execution. We verify that a modification is overwritten by another modification, only if the latter one comes with a higher timestamp.
