### PR TITLE
Make Compression Configurable

### DIFF
--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
@@ -39,6 +39,12 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
 
     public static final String WRITE_CONSISTENCY_LEVEL_KEY = "write-consistency-level";
 
+    public static final String SSTABLE_COMPRESSOR = "sstable-compressor";
+    public static final String COMPRESSION_CHUNK_LENGTH = "compression-chunk-length";
+
+    protected final String sstableCompressionClass;
+    protected final int compressionChunkSizeKB;
+
     /**
      * THRIFT_FRAME_SIZE_IN_MB should be appropriately set when server-side Thrift counterpart was changed,
      * because otherwise client wouldn't be able to accept read/write frames from server as incorrectly sized.
@@ -110,6 +116,8 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
                 WRITE_CONSISTENCY_LEVEL_KEY, WRITE_CONSISTENCY_LEVEL_DEFAULT));
 
         this.thriftFrameSize = storageConfig.getInt(THRIFT_FRAME_SIZE_MB, THRIFT_DEFAULT_FRAME_SIZE) * 1024 * 1024;
+        this.sstableCompressionClass = storageConfig.getString(SSTABLE_COMPRESSOR, "SnappyCompressor");
+        this.compressionChunkSizeKB = new Integer(storageConfig.getString(COMPRESSION_CHUNK_LENGTH, "64"));
     }
 
     public abstract Partitioner getPartitioner() throws StorageException;

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
@@ -305,14 +305,11 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
                         cl.makeColumnFamilyDefinition()
                                 .setName(name)
                                 .setKeyspace(keySpaceName)
-                                .setComparatorType(comparator)
-                                .setCompressionOptions(
-                                		new ImmutableMap.Builder<String, String>()
-                                			.put("sstable_compression", "SnappyCompressor")
-                                			.put("chunk_length_kb", "64")
-                                			.build()
-                                );
-                cl.addColumnFamily(cfDef);
+                                .setComparatorType(comparator);
+                ImmutableMap.Builder<String, String> compressionOptions = new ImmutableMap.Builder<String, String>();
+                compressionOptions.put("sstable_compression", sstableCompressionClass)
+                                  .put("chunk_length_kb", Integer.toString(compressionChunkSizeKB));
+                cl.addColumnFamily(cfDef.setCompressionOptions(compressionOptions.build()));
             }
         } catch (ConnectionException e) {
             throw new TemporaryStorageException(e);

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
@@ -31,8 +31,7 @@ import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.RequestExecutionException;
-import org.apache.cassandra.io.compress.CompressionParameters;
-import org.apache.cassandra.io.compress.SnappyCompressor;
+import org.apache.cassandra.io.compress.*;
 import org.apache.cassandra.scheduler.IRequestScheduler;
 import org.apache.cassandra.service.MigrationManager;
 import org.apache.cassandra.service.StorageProxy;
@@ -42,6 +41,7 @@ import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
@@ -323,13 +323,18 @@ public class CassandraEmbeddedStoreManager extends AbstractCassandraStoreManager
         }
         
         // Enable snappy compression
+        Class<?> compressorClass;
+        CompressionParameters cp;
         try {
-            CompressionParameters cp = new CompressionParameters(new SnappyCompressor(), 64 * 1024, ImmutableMap.<String, String>of());
-            cfm.compressionParameters(cp);
-            log.debug("Set CompressionParameters {}", cp);
-        } catch (ConfigurationException e) {
+            compressorClass = Class.forName(sstableCompressionClass);
+            Method method = compressorClass.getMethod("create", Map.class);
+        	ICompressor compressor = (ICompressor) method.invoke(null, new HashMap<String, String>());
+            cp = new CompressionParameters(compressor, compressionChunkSizeKB * 1024, ImmutableMap.<String, String>of());
+        } catch (Exception e) {
             throw new PermanentStorageException("Failed to create compression parameters for " + keyspaceName + ":" + columnfamilyName, e);
         }
+        cfm.compressionParameters(cp);
+        log.debug("Set CompressionParameters {}", cp);
 
         try {
             cfm.addDefaultIndexNames();

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -381,7 +381,7 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
         }
     }
 
-    private static void createColumnFamily(Cassandra.Client client,
+    private void createColumnFamily(Cassandra.Client client,
                                            String ksName,
                                            String cfName,
                                            String comparator) throws StorageException {
@@ -390,13 +390,11 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
         createColumnFamily.setName(cfName);
         createColumnFamily.setKeyspace(ksName);
         createColumnFamily.setComparator_type(comparator);
-        createColumnFamily.setCompression_options(
-        		new ImmutableMap.Builder<String, String>()
-    			.put("sstable_compression", "SnappyCompressor")
-    			.put("chunk_length_kb", "64")
-    			.build()
-    	);
-
+        ImmutableMap.Builder<String, String> compressionOptions = new ImmutableMap.Builder<String, String>();
+        compressionOptions.put("sstable_compression", sstableCompressionClass)
+                          .put("chunk_length_kb", Integer.toString(compressionChunkSizeKB));
+        createColumnFamily.setCompression_options(compressionOptions.build());
+        
         // Hard-coded caching settings
         if (cfName.startsWith(Backend.EDGESTORE_NAME)) {
             createColumnFamily.setCaching("keys_only");


### PR DESCRIPTION
Making Cassandra compression algorithm configurable via two new configuration properties (storage.sstable-compressor and storage.compression-chunk-length).  This is another solution to Issue #397 (I didn't even notice the pull request for that until I went to submit this one).  I think this pull request addresses the problem with a little more flexibility.  The other pull request is just a "turn off compression" switch, while this one lets you specify a different class to do the compression.  So you could use org.apache.cassandra.io.compress.DeflateCompressor for simple zip compression (compresses more, but slower) or you could write your own compressor implementing org.apache.cassandra.io.compress.ICompressor which used something like the snappy library that doesn't have native components (https://github.com/dain/snappy/).  Or I guess you could write a no-op one if you really, really don't want compression.  Otherwise, these two pull requests are nearly identical (I was actually able to clean mine up a bit after reviewing the other one).
