### PR TITLE
Add support for search within polygon Geoshape

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
@@ -257,6 +257,39 @@ public class Geoshape {
     }
 
     /**
+     * Constructs a new polygon shape which is identified by its coordinates
+     * @param coordinates
+     * @return
+     */
+    public static final Geoshape polygon(final float ... coordinates) {
+        Preconditions.checkArgument(coordinates.length % 2 == 0, "Odd number of coordinates provided");
+        Preconditions.checkArgument(coordinates.length >= 6, "Too few coordinate pairs provided");
+        float[] latitudes = new float[coordinates.length / 2];
+        float[] longitudes = new float[coordinates.length / 2];
+        for (int i = 0; i < coordinates.length; i++) {
+            if (i % 2 == 0) {
+                latitudes[i / 2] = coordinates[i];
+            } else {
+                longitudes[i / 2] = coordinates[i];
+            }
+        }
+        return new Geoshape(new float[][]{ latitudes, longitudes });
+    }
+
+    /**
+     * Constructs a new polygon shape which is identified by its coordinates
+     * @param coordinates
+     * @return
+     */
+    public static final Geoshape polygon(final double ... coordinates) {
+        float[] floatCoordinates = new float[coordinates.length];
+        for (int i = 0; i < coordinates.length; i++) {
+            floatCoordinates[i] = (float)coordinates[i];
+        }
+        return polygon(floatCoordinates);
+    }
+
+    /**
      * Whether the given coordinates mark a point on earth.
      * @param latitude
      * @param longitude

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -424,6 +424,13 @@ public class ElasticSearchIndex implements IndexProvider {
                     Geoshape.Point southwest = shape.getPoint(0);
                     Geoshape.Point northeast = shape.getPoint(1);
                     return FilterBuilders.geoBoundingBoxFilter(key).bottomRight(southwest.getLatitude(), northeast.getLongitude()).topLeft(northeast.getLatitude(), southwest.getLongitude());
+                } else if (shape.getType() == Geoshape.Type.POLYGON) {
+                    GeoPolygonFilterBuilder polygonFilter = FilterBuilders.geoPolygonFilter(key);
+                    for (int i = 0; i < shape.size(); i++) {
+                        Geoshape.Point point = shape.getPoint(i);
+                        polygonFilter.addPoint(point.getLatitude(), point.getLongitude());
+                    }
+                    return polygonFilter;
                 } else
                     throw new IllegalArgumentException("Unsupported or invalid search shape type: " + shape.getType());
             } else throw new IllegalArgumentException("Unsupported type: " + value);

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexProviderTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexProviderTest.java
@@ -162,6 +162,10 @@ public abstract class IndexProviderTest {
             assertEquals(2, result.size());
             assertEquals(ImmutableSet.of("doc1", "doc2"), ImmutableSet.copyOf(result));
 
+            result = tx.query(new IndexQuery(store, PredicateCondition.of("location", Geo.WITHIN, Geoshape.polygon(48.5,0.0, 47.5,-0.5, 47.5,0.5))));
+            assertEquals(1, result.size());
+            assertEquals(ImmutableSet.of("doc1"), ImmutableSet.copyOf(result));
+
             result = tx.query(new IndexQuery(store, And.of(PredicateCondition.of("text", Text.CONTAINS, "tomorrow"), PredicateCondition.of("location", Geo.WITHIN, Geoshape.circle(48.5, 0.5, 200.00)))));
             assertEquals(ImmutableSet.of("doc2"), ImmutableSet.copyOf(result));
 


### PR DESCRIPTION
The current version of ElasticSearch supports the GeoPolygonFilter, so it was trivial to add support for polygons with an arbitray number of boundary points. Works great. I added a test and the suite passes.

The trickiest part of this is the interface to easily create a polygon Geoshape with both Java and Groovy syntax. This is where I ended up (seemed consistent with the other constructors), but I'm open to suggestions:

``` groovy
g.V.has('location', WITHIN, Geoshape.polygon(37.0,22.0, 40.0,22.0, 40.0,24.0, 37.0,24.0))
```

We could support `ArrayList<double>(2)` arguments to make the Groovy a bit nicer, but it would increase the complexity. Thoughts?
