### PR TITLE
multiQuery has(), g.V('pk', byteArray) bug patches.

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/SerializerInitialization.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/SerializerInitialization.java
@@ -30,7 +30,7 @@ public class SerializerInitialization {
         serializer.registerClass(int[].class, KRYO_OFFSET + 9);
         serializer.registerClass(double[].class, KRYO_OFFSET + 10);
         serializer.registerClass(long[].class, KRYO_OFFSET + 11);
-        serializer.registerClass(byte[].class, KRYO_OFFSET + 12);
+        serializer.registerClass(byte[].class, new ByteArrayHandler(), KRYO_OFFSET + 12);
         serializer.registerClass(boolean[].class, KRYO_OFFSET + 13);
         serializer.registerClass(IndexType.class, KRYO_OFFSET + 14);
         serializer.registerClass(TitanTypeClass.class, KRYO_OFFSET + 15);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/ByteArrayHandler.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/ByteArrayHandler.java
@@ -1,0 +1,30 @@
+package com.thinkaurelius.titan.graphdb.database.serialize.attribute;
+
+import java.util.List;
+
+import com.thinkaurelius.titan.core.AttributeHandler;
+
+public class ByteArrayHandler implements AttributeHandler<byte[]> {
+
+    @Override
+    public void verifyAttribute(byte[] value) {
+        //All values are valid
+    }
+
+    @Override
+    public byte[] convert(Object value) {
+        if(value instanceof List) {
+        	if(((List)value).get(0) instanceof Byte) {
+	            List<Byte> byteList = (List<Byte>)value;
+	            byte[] buff = new byte[byteList.size()];
+	            for(int i=0; i<byteList.size(); i++) {
+	                buff[i] = byteList.get(i);
+	            }
+	            return buff;
+        	}
+        } else if (value instanceof byte[]) {
+        	return (byte[])value;
+        }
+        return null;
+    }
+}

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/QueryUtil.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/QueryUtil.java
@@ -64,8 +64,13 @@ public class QueryUtil {
         if (isQNFLiteralOrNot(condition)) return true;
         else if (condition instanceof And) {
             for (Condition<?> child : ((And<?>) condition).getChildren()) {
-                if (isQNFLiteralOrNot(child)) continue;
-                else if (child instanceof Or) {
+                if (isQNFLiteralOrNot(child)) {
+                    continue;
+                } else if (child instanceof And) {
+                    for (Condition<?> child2 : ((And<?>) child).getChildren()) {
+                        if (!isQNFLiteralOrNot(child2)) return false;
+                    }
+                } else if (child instanceof Or) {
                     for (Condition<?> child2 : ((Or<?>) child).getChildren()) {
                         if (!isQNFLiteralOrNot(child2)) return false;
                     }


### PR DESCRIPTION
multiQuery has() throwing IllegalArgumentException bug fix.
https://github.com/thinkaurelius/titan/issues/439 bug fix patch.

Cannot query g.V('primaryKey', byteArray) because byte[] is converted to List<Byte>
https://github.com/thinkaurelius/titan/issues/443 bug fix patch.
