### PR TITLE
Fix memory leaks in LRUVertexCache and StandardTitanTx

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
@@ -181,7 +181,7 @@ public class StandardTitanTx extends TitanBlueprintsTransaction {
             public int weigh(IndexQuery q, List<Object> r) {
                 return 2 + r.size();
             }
-        }).concurrencyLevel(concurrencyLevel).maximumWeight(config.getIndexCacheWeight()).build();
+        }).concurrencyLevel(concurrencyLevel).maximumWeight(config.getIndexCacheWeight()).softValues().build();
 
         uniqueLocks = UNINITIALIZED_LOCKS;
         deletedRelations = EMPTY_DELETED_RELATIONS;
@@ -966,7 +966,9 @@ public class StandardTitanTx extends TitanBlueprintsTransaction {
     }
 
     private void close() {
-        //TODO: release non crucial data structures to preserve memory?
+        vertexCache.close();
+        indexCache.invalidateAll();
+        indexCache.cleanUp();
         isOpen = false;
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/vertexcache/LRUVertexCache.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/vertexcache/LRUVertexCache.java
@@ -1,7 +1,5 @@
 package com.thinkaurelius.titan.graphdb.transaction.vertexcache;
 
-import com.carrotsearch.hppc.ObjectContainer;
-import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.*;
 import com.thinkaurelius.titan.graphdb.internal.InternalVertex;
@@ -33,7 +31,7 @@ public class LRUVertexCache implements VertexCache {
                         }
                     }
                 })
-                .build();
+                .softValues().build();
     }
 
     @Override
@@ -82,12 +80,10 @@ public class LRUVertexCache implements VertexCache {
         return vertices;
     }
 
-
     @Override
     public synchronized void close() {
-        cache.cleanUp();
+        addedRelVertices.clear();
         cache.invalidateAll();
+        cache.cleanUp();
     }
-
-
 }


### PR DESCRIPTION
The recently introduced LRUVertexCache slowly consumes tenured heap over time.  Transaction commit and rollback were not completely releasing cache resources used by the transaction during its lifetime.

I believe it is wise to build the vertex cache with softValues() along with a maximum capacity.  This way, applications can recover from misjudgments in setting the transaction cache capacity rather than throwing excessive GC overhead exceptions.
