### PR TITLE
MapR Tables (HBase) supported as Titan Backend

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -11,6 +11,7 @@ h2. Features
 * Support for various "storage backends":https://github.com/thinkaurelius/titan/wiki/Storage-Backend-Overview:
 ** "Apache Cassandra":http://cassandra.apache.org/ (distributed)
 ** "Apache HBase":http://hbase.apache.org/ (distributed)
+** "MapR Tables":http://www.mapr.com/products/mapr-editions/m7-edition (distributed)
 ** "Oracle BerkeleyDB":http://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html (local)
 ** "Persistit":https://github.com/pdbeaman/persistit (local)
 * Support for various "indexing backends":https://github.com/thinkaurelius/titan/wiki/Indexing-Backend-Overview:

--- a/titan-hbase/pom.xml
+++ b/titan-hbase/pom.xml
@@ -184,5 +184,51 @@
                 </dependency>
             </dependencies>
         </profile>
+	<profile>
+	    <id>mapr-m7</id>
+	    <properties>
+	        <hbase.version>0.94.12-mapr-1310</hbase.version>
+	        <hadoop.version>1.0.3-mapr-3.0.2</hadoop.version>
+	        <mapr.zookeeper.version>3.3.6</mapr.zookeeper.version>
+	    </properties>
+	    <repositories>
+	        <repository>
+	            <id>mapr-releases</id>
+	            <url>http://repository.mapr.com/maven/</url>
+	            <snapshots>
+		        <enabled>false</enabled>
+	            </snapshots>
+	            <releases>
+		        <enabled>true</enabled>
+	            </releases>
+	        </repository>
+	    </repositories>
+            <dependencies>
+	        <dependency>
+	            <groupId>com.mapr.fs</groupId>
+	            <artifactId>mapr-hbase</artifactId>
+	            <version>${hadoop.version}</version>
+	        </dependency>
+            </dependencies>
+	    <dependencyManagement>
+                <dependencies>
+	            <dependency>
+	                <groupId>org.apache.zookeeper</groupId>
+	                <artifactId>zookeeper</artifactId>
+	                <version>${mapr.zookeeper.version}</version>
+	            </dependency>
+	            <dependency>
+	                <groupId>commons-configuration</groupId>
+	                <artifactId>commons-configuration</artifactId>
+	                <version>1.8</version>
+	            </dependency>
+	            <dependency>
+	                <groupId>org.mortbay.jetty</groupId>
+	                <artifactId>jetty-util</artifactId>
+	                <version>6.1.26</version>
+	            </dependency>
+	        </dependencies>
+            </dependencyManagement>
+        </profile>
     </profiles>
 </project>

--- a/titan-hbase/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
+++ b/titan-hbase/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
@@ -269,8 +269,8 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
         if (cf == null) {
             try {
                 adm.disableTable(tableName);
-                desc.addFamily(new HColumnDescriptor(columnFamily).setCompressionType(Compression.Algorithm.GZ));
-                adm.modifyTable(tableName.getBytes(), desc);
+                cf = new HColumnDescriptor(columnFamily);
+                adm.addColumn(tableName, cf);
 
                 try {
                     logger.debug("Added HBase ColumnFamily {}, waiting for 1 sec. to propogate.", columnFamily);


### PR DESCRIPTION
Here are my changes that were required to use MapR jar files.  I think they're unobtrusive, as you only use this with the 'mapr-m7' maven profile.

Also, there was a call to what I would characterize as unreliable modifyTable() in HBase.  This patch works with both MapR tables as well as Apache HBase, and is probably the solution to thinkaurelius/titan#165.
