### PR TITLE
Allow Geoshapes to be parsed from a variety of formats

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/GeoshapeHandler.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/GeoshapeHandler.java
@@ -5,12 +5,18 @@ import com.thinkaurelius.titan.core.AttributeHandler;
 import com.thinkaurelius.titan.core.attribute.Geoshape;
 
 import java.lang.reflect.Array;
+import java.util.List;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
  */
 
 public class GeoshapeHandler implements AttributeHandler<Geoshape> {
+
+    private static final String POINT_PREFIX = "point[";
+    private static final String CIRCLE_PREFIX = "circle[";
+    private static final String BOX_PREFIX = "box[";
+    private static final String SUFFIX = "]";
 
     @Override
     public void verifyAttribute(Geoshape value) {
@@ -21,32 +27,83 @@ public class GeoshapeHandler implements AttributeHandler<Geoshape> {
     public Geoshape convert(Object value) {
         if (value.getClass().isArray() && (value.getClass().getComponentType().isPrimitive() ||
                 Number.class.isAssignableFrom(value.getClass().getComponentType())) ) {
-            Geoshape shape = null;
-            int len= Array.getLength(value);
+            int len = Array.getLength(value);
             double[] arr = new double[len];
-            for (int i=0;i<len;i++) arr[i]=((Number)Array.get(value,i)).doubleValue();
-            if (len==2) shape=Geoshape.point(arr[0],arr[1]);
-            else if (len==3) shape=Geoshape.circle(arr[0],arr[1],arr[2]);
-            else if (len==4) shape=Geoshape.box(arr[0],arr[1],arr[2],arr[3]);
-            else throw new IllegalArgumentException("Expected 2-4 coordinates to create Geoshape, but given: " + value);
-            return shape;
+            for (int i=0;i<len;i++) {
+                arr[i] = ((Number)Array.get(value, i)).doubleValue();
+            }
+            return convertArray(arr);
+        } else if (value instanceof List) {
+            List list = (List)value;
+            double[] arr = new double[list.size()];
+
+            int i = 0;
+            for (Object coord: list) {
+                Preconditions.checkArgument(coord != null && Number.class.isAssignableFrom(coord.getClass()),
+                        "Could not parse coordinates from list: %s", value);
+                arr[i] = ((Number)coord).doubleValue();
+                i += 1;
+            }
+
+            return convertArray(arr);
         } else if (value instanceof String) {
-            String[] components=null;
-            for (String delimiter : new String[]{",",";"}) {
-                components = ((String)value).split(delimiter);
-                if (components.length>=2 && components.length<=4) break;
-                else components=null;
+            String string = (String)value;
+            double[] coords;
+
+            if (string.startsWith(POINT_PREFIX)) {
+                Preconditions.checkArgument(string.endsWith(SUFFIX), "Could not parse coordinates from string: %s", value);
+                coords = parseString(string.substring(POINT_PREFIX.length(), string.length() - 1));
+                Preconditions.checkArgument(coords.length == 2, "Expected 2 components for box: %s", value);
+
+            } else if (string.startsWith(CIRCLE_PREFIX)) {
+                Preconditions.checkArgument(string.endsWith(SUFFIX), "Could not parse coordinates from string: %s", value);
+                coords = parseString(string.substring(CIRCLE_PREFIX.length(), string.length() - 1));
+                Preconditions.checkArgument(coords.length == 3, "Expected 3 components for circle: %s", value);
+
+            } else if (string.startsWith(BOX_PREFIX)) {
+                Preconditions.checkArgument(string.endsWith(SUFFIX), "Could not parse coordinates from string: %s", value);
+                coords = parseString(string.substring(BOX_PREFIX.length(), string.length() - 1));
+                Preconditions.checkArgument(coords.length == 4, "Expected 4 components for box: %s", value);
+
+            } else {
+                coords = parseString(string);
             }
-            Preconditions.checkArgument(components!=null,"Could not parse coordinates from string: %s",value);
-            double[] coords = new double[components.length];
-            try {
-                for (int i=0;i<components.length;i++) {
-                    coords[i]=Double.parseDouble(components[i]);
-                }
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Could not parse coordinates from string: " + value, e);
-            }
-            return convert(coords);
+
+            return convertArray(coords);
         } else return null;
+    }
+
+    private Geoshape convertArray(double[] arr) {
+        switch (arr.length) {
+            case 2: return Geoshape.point(arr[0], arr[1]);
+            case 3: return Geoshape.circle(arr[0], arr[1], arr[2]);
+            case 4: return Geoshape.box(arr[0], arr[1], arr[2], arr[3]);
+            default: {
+                throw new IllegalArgumentException("Expected 2-4 coordinates to create Geoshape, but given: " + arr);
+            }
+        }
+    }
+
+    private double[] parseString(String string) {
+        String[] components = null;
+
+        for (String delimiter : new String[]{",",";"}) {
+            components = string.split(delimiter);
+            if (components.length>=2 && components.length<=4) break;
+            else components = null;
+        }
+
+        Preconditions.checkArgument(components != null, "Could not parse coordinates from string: %s", string);
+
+        double[] coords = new double[components.length];
+        try {
+            for (int i = 0; i < components.length; i++) {
+                coords[i]=Double.parseDouble(components[i]);
+            }
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Could not parse coordinates from string: " + string, e);
+        }
+
+        return coords;
     }
 }

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/GeoshapeHandlerTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/GeoshapeHandlerTest.java
@@ -1,0 +1,91 @@
+package com.thinkaurelius.titan.graphdb.serializer;
+
+import com.thinkaurelius.titan.core.attribute.Geoshape;
+import com.thinkaurelius.titan.graphdb.database.serialize.attribute.GeoshapeHandler;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Matthias Broecheler (me@matthiasb.com)
+ */
+
+public class GeoshapeHandlerTest {
+
+    @Test
+    public void testString() {
+        GeoshapeHandler handler = new GeoshapeHandler();
+
+        assertEquals(handler.convert("1,2"), Geoshape.point(1, 2));
+        assertEquals(handler.convert("1,2,4"), Geoshape.circle(1, 2, 4));
+        assertEquals(handler.convert("1,2,4,8"), Geoshape.box(1, 2, 4, 8));
+
+        assertEquals(handler.convert("point[1,2]"), Geoshape.point(1, 2));
+        assertEquals(handler.convert("circle[1,2,4]"), Geoshape.circle(1, 2, 4));
+        assertEquals(handler.convert("box[1,2,4,8]"), Geoshape.box(1, 2, 4, 8));
+
+        String[] strings = {
+                "",
+                "1",
+                "1,2,4,8,16",
+                "point[", "point[]", "point[1]", "point[1,2,4]",
+                "circle[", "circle[1,2]", "circle[1,2,4,8]",
+                "box[", "box[1,2]", "box[1,2,4]", "box[1,2,4,8,16]"
+        };
+
+        for(String string: strings) {
+            try {
+                handler.convert(string);
+                fail("should have failed to parse: \"" + string + "\"");
+            } catch (IllegalArgumentException e) {
+            }
+        }
+    }
+
+    @Test
+    public void testArray() {
+        GeoshapeHandler handler = new GeoshapeHandler();
+
+        assertEquals(handler.convert(new double[] {1, 2}), Geoshape.point(1, 2));
+        assertEquals(handler.convert(new double[] {1, 2, 4}), Geoshape.circle(1, 2, 4));
+        assertEquals(handler.convert(new double[] {1, 2, 4, 8}), Geoshape.box(1, 2, 4, 8));
+
+        double[][] arrays = {
+                new double[] {1},
+                new double[] {1, 2, 4, 8, 16}
+        };
+
+        for(double[] array: arrays) {
+            try {
+                handler.convert(array);
+                fail("should have failed to parse: \"" + array + "\"");
+            } catch (IllegalArgumentException e) {
+            }
+        }
+    }
+
+    @Test
+    public void testList() {
+        GeoshapeHandler handler = new GeoshapeHandler();
+
+        assertEquals(handler.convert(Arrays.asList(1, 2)), Geoshape.point(1, 2));
+        assertEquals(handler.convert(Arrays.asList(1, 2, 4)), Geoshape.circle(1, 2, 4));
+        assertEquals(handler.convert(Arrays.asList(1, 2, 4, 8)), Geoshape.box(1, 2, 4, 8));
+
+        List<List<Integer>> lists = Arrays.asList(
+                Arrays.asList(1),
+                Arrays.asList(1, 2, 4, 8, 16)
+        );
+
+        for(List<Integer> list: lists) {
+            try {
+                handler.convert(list);
+                fail("should have failed to parse: \"" + lists + "\"");
+            } catch (IllegalArgumentException e) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows Geoshapes to be extract from a java `List`, or parsed from `"point[123,456]"`, `"circle[123,456,789]"`, and `"box[12,34,56,78]"`.

Fixes #572
