### PR TITLE
Use elasticsearch 1.0.0

### DIFF
--- a/titan-es/pom.xml
+++ b/titan-es/pom.xml
@@ -19,7 +19,7 @@
           which it depends and modify ../titan-lucene/pom.xml
           as necessary to keep the versions matched.
         -->
-        <elasticsearch.version>0.90.5</elasticsearch.version>
+        <elasticsearch.version>1.0.0</elasticsearch.version>
     </properties>
     <dependencies>
         <dependency>

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchConstants.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchConstants.java
@@ -27,6 +27,8 @@ public class ElasticSearchConstants {
         }
         
         String vs = props.getProperty("es.version");
+        // The string formatting here assumes that there's no Beta or RC
+        // suffix.
         String versionConstantName = String.format("V_%s_%s_%s", (Object[])vs.split("\\."));
         ES_VERSION_EXPECTED = getExpectedVersionReflectively(versionConstantName);
     }

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -18,7 +18,6 @@ import com.thinkaurelius.titan.graphdb.query.condition.*;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.ElasticSearchInterruptedException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -175,7 +174,7 @@ public class ElasticSearchIndex implements IndexProvider {
     }
 
     private StorageException convert(Exception esException) {
-        if (esException instanceof ElasticSearchInterruptedException) {
+        if (esException instanceof InterruptedException) {
             return new TemporaryStorageException("Interrupted while waiting for response", esException);
         } else {
             return new PermanentStorageException("Unknown exception while executing index operation", esException);
@@ -438,7 +437,7 @@ public class ElasticSearchIndex implements IndexProvider {
         SearchRequestBuilder srb = client.prepareSearch(indexName);
         srb.setTypes(query.getStore());
         srb.setQuery(QueryBuilders.matchAllQuery());
-        srb.setFilter(getFilter(query.getCondition(),informations.get(query.getStore())));
+        srb.setPostFilter(getFilter(query.getCondition(),informations.get(query.getStore())));
         if (!query.getOrder().isEmpty()) {
             List<IndexQuery.OrderEntry> orders = query.getOrder();
             for (int i = 0; i < orders.size(); i++) {

--- a/titan-lucene/pom.xml
+++ b/titan-lucene/pom.xml
@@ -29,7 +29,7 @@
           dependency behind the ES version declared in the titan-es
           module.
         -->
-        <lucene.version>4.4.0</lucene.version>
+        <lucene.version>4.6.1</lucene.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Changelog
- Use elasticsearch 1.0.0 and lucene 4.6.1; to be determined whether the lucene version bump breaks anything.
- Change `SearchRequestBuilder.setFilter` to `SearchRequestBuilder.setPostFilter` [see this](http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_search_requests.html).

Are there any other changes that must be made?

`mvn test` passes on my machine.
