### PR TITLE
fix readme link to persistit

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -12,7 +12,7 @@ h2. Features
 ** "Apache Cassandra":http://cassandra.apache.org/ (distributed)
 ** "Apache HBase":http://hbase.apache.org/ (distributed)
 ** "Oracle BerkeleyDB":http://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html (local)
-** "Persistit":https://github.com/pdbeaman/persistit (local)
+** "Persistit":https://github.com/pbeaman/persistit (local)
 * Support for various "indexing backends":https://github.com/thinkaurelius/titan/wiki/Indexing-Backend-Overview:
 ** "ElasticSearch":http://www.elasticsearch.org/
 ** "Apache Lucene":http://lucene.apache.org/


### PR DESCRIPTION
This 1-character change fixes a README URL to the persistit repo.
