### PR TITLE
Optional utf8 serialization

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -700,6 +700,14 @@ public class GraphDatabaseConfiguration {
     public static final String GRAPHITE_PREFIX_KEY = "prefix";
     public static final String GRAPHITE_PREFIX_DEFAULT = null;
 
+    /**
+     * String attribute serialization could be by default Kryo serialization
+     * By default, set to false to maintain backward compatibility
+     */
+    public static final String STRING_UTF_SERIALIZATION = SERIALIZER_PREFIX + ".string.utf8";
+    public static final boolean STRING_UTF_SERIZLIZATION_DEFAULT = false;
+
+
     private final Configuration configuration;
 
     private boolean readOnly;
@@ -1205,7 +1213,7 @@ public class GraphDatabaseConfiguration {
 
     public Serializer getSerializer() {
         Configuration config = configuration.subset(ATTRIBUTE_NAMESPACE);
-        Serializer serializer = new KryoSerializer(config.getBoolean(ATTRIBUTE_ALLOW_ALL_SERIALIZABLE_KEY, ATTRIBUTE_ALLOW_ALL_SERIALIZABLE_DEFAULT));
+        Serializer serializer = new KryoSerializer(config);
         for (RegisteredAttributeClass<?> clazz : getRegisteredAttributeClasses(config)) {
             clazz.registerWith(serializer);
         }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/SerializerInitialization.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/SerializerInitialization.java
@@ -1,5 +1,6 @@
 package com.thinkaurelius.titan.graphdb.database.serialize;
 
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.core.Parameter;
 import com.thinkaurelius.titan.core.attribute.FullDouble;
@@ -17,11 +18,14 @@ public class SerializerInitialization {
     private static final int KRYO_OFFSET = 40;
     public static final int RESERVED_ID_OFFSET = 256;
 
-    public static final void initialize(Serializer serializer) {
+    public static final void initialize(Serializer serializer,boolean stringUtf8) {
         serializer.registerClass(String[].class, KRYO_OFFSET + 1);
         serializer.registerClass(TypeAttributeType.class, KRYO_OFFSET + 2);
         serializer.registerClass(TypeAttribute.class, KRYO_OFFSET + 3);
-        serializer.registerClass(String.class, new StringSerializer(), KRYO_OFFSET + 4);
+        if(stringUtf8) //default kryo serialization is utf8
+            serializer.registerClass(String.class,KRYO_OFFSET+4);
+        else
+            serializer.registerClass(String.class,new StringSerializer(),KRYO_OFFSET+4);
         serializer.registerClass(Date.class, new DateSerializer(), KRYO_OFFSET + 6);
         serializer.registerClass(ArrayList.class, KRYO_OFFSET + 7);
         serializer.registerClass(HashMap.class, KRYO_OFFSET + 8);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/kryo/KryoSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/kryo/KryoSerializer.java
@@ -18,6 +18,7 @@ import com.thinkaurelius.titan.graphdb.database.serialize.Serializer;
 import com.thinkaurelius.titan.graphdb.database.serialize.SerializerInitialization;
 import com.thinkaurelius.titan.graphdb.database.serialize.DefaultAttributeHandling;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public class KryoSerializer extends DefaultAttributeHandling implements Serializ
 
     private boolean initialized=false;
 
+    public KryoSerializer(){
+	    this(new PropertiesConfiguration());
+    }
 
     public KryoSerializer(Configuration config) {
         final boolean allowAllSerializable = config.getBoolean(ATTRIBUTE_ALLOW_ALL_SERIALIZABLE_KEY,ATTRIBUTE_ALLOW_ALL_SERIALIZABLE_DEFAULT);
@@ -56,7 +60,7 @@ public class KryoSerializer extends DefaultAttributeHandling implements Serializ
         this.registerRequired=!allowAllSerializable;
         this.registrations = new HashMap<Integer,TypeRegistration>();
 
-        log.info("Kryo serializer enabled with utf8: " + utf8);
+        log.warn("Kryo serializer enabled with utf8: " + utf8);
 
         kryos = new ThreadLocal<Kryo>() {
             public Kryo initialValue() {

--- a/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseKeyColumnValueUTF8Test.java
+++ b/titan-hbase/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseKeyColumnValueUTF8Test.java
@@ -1,0 +1,31 @@
+package com.thinkaurelius.titan.diskstorage.hbase;
+
+import com.thinkaurelius.titan.diskstorage.KeyValueStoreUtil;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import com.thinkaurelius.titan.graphdb.database.serialize.kryo.KryoSerializer;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author janar@
+ */
+public class HBaseKeyColumnValueUTF8Test extends HBaseKeyColumnValueTest
+{
+    @Before
+    @Override
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        Configuration conf  = new PropertiesConfiguration();
+        conf.setProperty(GraphDatabaseConfiguration.STRING_UTF_SERIALIZATION,true);
+        KeyValueStoreUtil.serial = new KryoSerializer(conf);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        KeyValueStoreUtil.serial = new KryoSerializer();
+    }
+}

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreUtil.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreUtil.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 public class KeyValueStoreUtil {
 
     private static final Logger log = LoggerFactory.getLogger(KeyValueStoreUtil.class);
-    public static final Serializer serial = new KryoSerializer(true);
+    public static final Serializer serial = new KryoSerializer();
     public static final long idOffset = 1000;
 
     public static final StaticBuffer MIN_KEY = ByteBufferUtil.getLongBuffer(0);

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreUtil.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreUtil.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 public class KeyValueStoreUtil {
 
     private static final Logger log = LoggerFactory.getLogger(KeyValueStoreUtil.class);
-    public static final Serializer serial = new KryoSerializer();
+    public static Serializer serial = new KryoSerializer();
     public static final long idOffset = 1000;
 
     public static final StaticBuffer MIN_KEY = ByteBufferUtil.getLongBuffer(0);

--- a/titan-test/src/test/java/com/thinkaurelius/titan/diskstorage/inmemory/InMemoryKeyColumnValueStoreUTF8Test.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/diskstorage/inmemory/InMemoryKeyColumnValueStoreUTF8Test.java
@@ -1,0 +1,47 @@
+package com.thinkaurelius.titan.diskstorage.inmemory;
+
+import com.thinkaurelius.titan.diskstorage.KeyColumnValueStoreTest;
+import com.thinkaurelius.titan.diskstorage.KeyValueStoreUtil;
+import com.thinkaurelius.titan.diskstorage.StorageException;
+import com.thinkaurelius.titan.diskstorage.keycolumnvalue.KeyColumnValueStoreManager;
+import com.thinkaurelius.titan.diskstorage.keycolumnvalue.inmemory.InMemoryStoreManager;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import com.thinkaurelius.titan.graphdb.database.serialize.kryo.KryoSerializer;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author janar@
+ */
+public class InMemoryKeyColumnValueStoreUTF8Test extends KeyColumnValueStoreTest {
+
+    @Before
+    @Override
+    public void setUp() throws Exception
+    {
+        super.setUp();
+        Configuration conf  = new PropertiesConfiguration();
+        conf.setProperty(GraphDatabaseConfiguration.STRING_UTF_SERIALIZATION,true);
+        KeyValueStoreUtil.serial = new KryoSerializer(conf);
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        KeyValueStoreUtil.serial = new KryoSerializer();
+    }
+
+    @Override
+    public KeyColumnValueStoreManager openStorageManager() throws StorageException {
+        return new InMemoryStoreManager();
+    }
+
+    @Override
+    public void clopen() {
+        //Do nothing
+    }
+
+}
+

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManagementTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/IDManagementTest.java
@@ -86,7 +86,7 @@ public class IDManagementTest {
         int trails = 1000000;
         assertEquals(eid.getMaxPartitionCount(), (1 << partitionBits) - 1);
 
-        KryoSerializer serializer = new KryoSerializer(true);
+        KryoSerializer serializer = new KryoSerializer();
         for (int t = 0; t < trails; t++) {
             long count = RandomGenerator.randomLong(1, eid.getMaxTitanTypeCount());
             long id;

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SerializerTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SerializerTest.java
@@ -3,6 +3,7 @@ package com.thinkaurelius.titan.graphdb.serializer;
 
 import com.thinkaurelius.titan.diskstorage.ReadBuffer;
 import com.thinkaurelius.titan.diskstorage.StaticBuffer;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.graphdb.database.serialize.DataOutput;
 import com.thinkaurelius.titan.graphdb.database.serialize.Serializer;
 import com.thinkaurelius.titan.graphdb.database.serialize.attribute.DoubleSerializer;
@@ -10,6 +11,8 @@ import com.thinkaurelius.titan.graphdb.database.serialize.attribute.FloatSeriali
 import com.thinkaurelius.titan.graphdb.database.serialize.kryo.KryoSerializer;
 import com.thinkaurelius.titan.testutil.PerformanceTest;
 import com.thinkaurelius.titan.testutil.RandomGenerator;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +34,9 @@ public class SerializerTest {
 
     @Before
     public void setUp() throws Exception {
-        serialize = new KryoSerializer(false);
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(GraphDatabaseConfiguration.ATTRIBUTE_ALLOW_ALL_SERIALIZABLE_KEY,true);
+        serialize = new KryoSerializer(conf);
         serialize.registerClass(TestEnum.class, RESERVED_ID_OFFSET + 1);
         serialize.registerClass(TestClass.class, RESERVED_ID_OFFSET + 2);
         serialize.registerClass(short[].class, RESERVED_ID_OFFSET + 3);
@@ -94,6 +99,7 @@ public class SerializerTest {
             assertEquals(s1 + " vs " + s2, Integer.signum(s1.compareTo(s2)), Integer.signum(b1.compareTo(b2)));
         }
     }
+
 
     @Test
     public void classSerialization() {
@@ -227,7 +233,7 @@ public class SerializerTest {
 
     @Test
     public void testObjectVerification() {
-        KryoSerializer s = new KryoSerializer(true);
+        KryoSerializer s = new KryoSerializer();
         DataOutput out = s.getDataOutput(128, true);
         Long l = Long.valueOf(128);
         out.writeClassAndObject(l);

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SerializerUTF8Test.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/serializer/SerializerUTF8Test.java
@@ -1,0 +1,75 @@
+package com.thinkaurelius.titan.graphdb.serializer;
+
+import com.thinkaurelius.titan.diskstorage.ReadBuffer;
+import com.thinkaurelius.titan.diskstorage.StaticBuffer;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+import com.thinkaurelius.titan.graphdb.database.serialize.DataOutput;
+import com.thinkaurelius.titan.graphdb.database.serialize.kryo.KryoSerializer;
+import com.thinkaurelius.titan.testutil.RandomGenerator;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.thinkaurelius.titan.graphdb.database.serialize.SerializerInitialization.RESERVED_ID_OFFSET;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Runs the rest of serialization test with utf8 setting. primarily intended only for the string test
+ * @author janar@
+ */
+public class SerializerUTF8Test extends SerializerTest
+{
+    @Before
+    public void setUp() throws Exception {
+        Configuration conf = new PropertiesConfiguration();
+        conf.setProperty(GraphDatabaseConfiguration.STRING_UTF_SERIALIZATION,true);
+        serialize = new KryoSerializer(conf);
+        serialize.registerClass(TestEnum.class, RESERVED_ID_OFFSET + 1);
+        serialize.registerClass(TestClass.class, RESERVED_ID_OFFSET + 2);
+        serialize.registerClass(short[].class, RESERVED_ID_OFFSET + 3);
+
+        printStats = true;
+    }
+
+    @Override
+    @Test
+    public void stringSerialization() {
+        //Characters
+        DataOutput out = serialize.getDataOutput(((int) Character.MAX_VALUE) * 2 + 8, true);
+        for (char c = Character.MIN_VALUE; c < Character.MAX_VALUE; c++) {
+            out.writeObjectNotNull(Character.valueOf(c));
+        }
+        ReadBuffer b = out.getStaticBuffer().asReadBuffer();
+        for (char c = Character.MIN_VALUE; c < Character.MAX_VALUE; c++) {
+            assertEquals(c, serialize.readObjectNotNull(b, Character.class).charValue());
+        }
+
+
+        //String
+        for (int t = 0; t < 10000; t++) {
+            DataOutput out1 = serialize.getDataOutput(32 + 5, true);
+            DataOutput out2 = serialize.getDataOutput(32 + 5, true);
+            String s1 = RandomGenerator.randomString(1, 32);
+            String s2 = RandomGenerator.randomString(1, 32);
+            out1.writeObjectNotNull(s1);
+            out2.writeObjectNotNull(s2);
+            StaticBuffer b1 = out1.getStaticBuffer();
+            StaticBuffer b2 = out2.getStaticBuffer();
+            assertEquals(s1, serialize.readObjectNotNull(b1.asReadBuffer(), String.class));
+            assertEquals(s2, serialize.readObjectNotNull(b2.asReadBuffer(), String.class));
+            //todo: sort order test fails because... a bug in StaticArrayBuffer.compareTo() and ByteBuffer.compareTo(), where we ignore sign bit for 'byte' during int conversion!
+            /*
+             * ByteBufferUtil.java:
+             * public static int compare(byte c1, byte c2) {
+             *    return new Byte(c1).compareTo(new Byte(c2));
+             * }
+             *
+             * the same in StaticArrayBuffer...
+             *
+             * But we seem to be relying on this bug elsewhere in the code.
+             */
+           //assertEquals(s1 + " vs " + s2, Integer.signum(s1.compareTo(s2)), Integer.signum(b1.compareTo(b2)));
+        }
+    }
+}


### PR DESCRIPTION
Skip the current serialization for only String and let Kryo use the default serialization.
