### PR TITLE
bin/ scripts to follow symlinks

### DIFF
--- a/titan-dist/src/assembly/static/bin/cassandra
+++ b/titan-dist/src/assembly/static/bin/cassandra
@@ -36,7 +36,20 @@
 # NB: Developers should be aware that this script should remain compatible with
 # POSIX sh and Solaris sh. This means, in particular, no $(( )) and no $( ).
 
-export CASSANDRA_INCLUDE="`dirname $0`/cassandra.in.sh"
+# Returns the absolute path of this script regardless of symlinks
+abs_path() {
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+}
+
+export CASSANDRA_INCLUDE="`abs_path`/cassandra.in.sh"
 . "$CASSANDRA_INCLUDE"
 
 # Use JAVA_HOME if set, otherwise look for java in PATH

--- a/titan-dist/src/assembly/static/bin/cassandra.in.sh
+++ b/titan-dist/src/assembly/static/bin/cassandra.in.sh
@@ -27,7 +27,7 @@ abs_path() {
     echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 }
 
-CASSANDRA_HOME=$(cd `abs_path` && pwd)
+CASSANDRA_HOME=$(cd `abs_path`/.. && pwd)
 
 # The directory where Cassandra's configs live (required)
 CASSANDRA_CONF=$CASSANDRA_HOME/conf

--- a/titan-dist/src/assembly/static/bin/cassandra.in.sh
+++ b/titan-dist/src/assembly/static/bin/cassandra.in.sh
@@ -14,8 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd `dirname $0`/..
-CASSANDRA_HOME=`pwd`
+# Returns the absolute path of this script regardless of symlinks
+abs_path() {
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+}
+
+CASSANDRA_HOME=$(cd `abs_path` && pwd)
 
 # The directory where Cassandra's configs live (required)
 CASSANDRA_CONF=$CASSANDRA_HOME/conf

--- a/titan-dist/src/assembly/static/bin/gremlin.sh
+++ b/titan-dist/src/assembly/static/bin/gremlin.sh
@@ -1,15 +1,28 @@
 #!/bin/bash
 
+# Returns the absolute path of this script regardless of symlinks
+abs_path() {
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+}
+
 case `uname` in
   CYGWIN*)
-    CP=`dirname $0`/../conf
-    CP=$CP;$( echo `dirname $0`/../lib/*.jar . | sed 's/ /;/g')
-    CP=$CP;$(find -L `dirname $0`/../ext/ -name "*.jar" | tr '\n' ';')
+    CP=`abs_path`/../conf
+    CP=$CP;$( echo `abs_path`/../lib/*.jar . | sed 's/ /;/g')
+    CP=$CP;$(find -L `abs_path`/../ext/ -name "*.jar" | tr '\n' ';')
     ;;
   *)
-    CP=`dirname $0`/../conf
-    CP=$CP:$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
-    CP=$CP:$(find -L `dirname $0`/../ext/ -name "*.jar" | tr '\n' ':')
+    CP=`abs_path`/../conf
+    CP=$CP:$( echo `abs_path`/../lib/*.jar . | sed 's/ /:/g')
+    CP=$CP:$(find -L `abs_path`/../ext/ -name "*.jar" | tr '\n' ':')
 esac
 #echo $CP
 

--- a/titan-dist/src/assembly/static/bin/rexster-console.sh
+++ b/titan-dist/src/assembly/static/bin/rexster-console.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
 set_unix_paths() {
-    BIN="$(dirname $0)"
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    BIN="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
     CP="$(echo $BIN/../conf $BIN/../lib/*.jar . | tr ' ' ':')"
     CP="$CP:$(find -L $BIN/../ext/ -name "*.jar" | tr '\n' ':')"
 }

--- a/titan-dist/src/assembly/static/bin/rexster.sh
+++ b/titan-dist/src/assembly/static/bin/rexster.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-BIN="`dirname $0`"
+# From: http://stackoverflow.com/a/246128
+#   - To resolve finding the directory after symlinks
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+BIN="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
 # Rexster doesn't allow GraphConfiguration implementations a clean way
 # to know the path to the rexster.xml config file.  This makes implementing
 # Titan's relative storage directory interpretation (relative to the file in

--- a/titan-dist/src/assembly/static/bin/titan.sh
+++ b/titan-dist/src/assembly/static/bin/titan.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
-BIN="`dirname $0`"
+# Returns the absolute path of this script regardless of symlinks
+abs_path() {
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+}
+
+BIN=`abs_path`
 REXSTER_CONFIG_TAG=cassandra-es
 : ${CASSANDRA_STARTUP_TIMEOUT_S:=60}
 : ${REXSTER_SHUTDOWN_TIMEOUT_S:=60}

--- a/titan-dist/src/assembly/static/bin/upgrade010to020.sh
+++ b/titan-dist/src/assembly/static/bin/upgrade010to020.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
 
+# Returns the absolute path of this script regardless of symlinks
+abs_path() {
+    # From: http://stackoverflow.com/a/246128
+    #   - To resolve finding the directory after symlinks
+    SOURCE="${BASH_SOURCE[0]}"
+    while [ -h "$SOURCE" ]; do
+        DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+        SOURCE="$(readlink "$SOURCE")"
+        [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    done
+    echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+}
+
 case `uname` in
   CYGWIN*)
-    CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /;/g')
-    CP=$CP:$(find -L `dirname $0`/../ext/ -name "*.jar" | tr '\n' ';')
+    CP=$( echo `abs_path`/../lib/*.jar . | sed 's/ /;/g')
+    CP=$CP:$(find -L `abs_path`/../ext/ -name "*.jar" | tr '\n' ';')
     ;;
   *)
-    CP=$( echo `dirname $0`/../lib/*.jar . | sed 's/ /:/g')
-    CP=$CP:$(find -L `dirname $0`/../ext/ -name "*.jar" | tr '\n' ':')
+    CP=$( echo `abs_path`/../lib/*.jar . | sed 's/ /:/g')
+    CP=$CP:$(find -L `abs_path`/../ext/ -name "*.jar" | tr '\n' ':')
 esac
-#echo $CP
 
 # Find Java
 if [ "$JAVA_HOME" = "" ] ; then


### PR DESCRIPTION
Since many applications now symlink one, or more, times into multiple directories these scripts needed updated to accurately follow said symlinks. Previously, if symlinks were present, the script would fail to find all of the .jar files in the library because it would only find the immediate path it was installed in. For example, if we symlinked rexster.sh to /usr/local/bin/rexster and attempted to call it, the script would only look in /usr/local/lib/ for its jar files which would fail to launch.

This is similar to the patch for the rexster-console script that was submitted a while back (tinkerpop/rexster#353) which details the discussion and problem.

The impetus for this patch is to get it fixed and in the upstream version for the next release build such that the homebrew formula to install titan (homebrew/homebrew#30107) can be accepted for the wider community.

Let me know if there are any issues or concerns!
