### PR TITLE
Bump ElasticSearch to 1.2.1, Lucene to 4.8.1

### DIFF
--- a/titan-core/pom.xml
+++ b/titan-core/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
-            <version>0.3</version>
+            <version>0.4.1</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>

--- a/titan-es/pom.xml
+++ b/titan-es/pom.xml
@@ -19,7 +19,7 @@
           which it depends and modify ../titan-lucene/pom.xml
           as necessary to keep the versions matched.
         -->
-        <elasticsearch.version>1.0.1</elasticsearch.version>
+        <elasticsearch.version>1.2.1</elasticsearch.version>
     </properties>
     <dependencies>
         <dependency>

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -147,6 +147,7 @@ public class ElasticSearchIndex implements IndexProvider {
                     if (!f.exists()) f.mkdirs();
                     b.put("path." + sub, subdir);
                 }
+                b.put("script.disable_dynamic", false);
                 builder.settings(b.build());
 
                 String clustername = config.get(CLUSTER_NAME);
@@ -169,6 +170,7 @@ public class ElasticSearchIndex implements IndexProvider {
             }
             log.debug("Transport sniffing enabled: {}", config.get(CLIENT_SNIFF));
             settings.put("client.transport.sniff", config.get(CLIENT_SNIFF));
+            settings.put("script.disable_dynamic", false);
             TransportClient tc = new TransportClient(settings.build());
             int defaultPort = config.has(INDEX_PORT)?config.get(INDEX_PORT):HOST_PORT_DEFAULT;
             for (String host : config.get(INDEX_HOSTS)) {

--- a/titan-lucene/pom.xml
+++ b/titan-lucene/pom.xml
@@ -29,7 +29,7 @@
           dependency behind the ES version declared in the titan-es
           module.
         -->
-        <lucene.version>4.6.1</lucene.version>
+        <lucene.version>4.8.1</lucene.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This updates the Titan 0.5 branch to use the current release of ElasticSearch, which also requires updating Lucene. This will be also useful to the Solr backend support (#372), which will end up using Lucene 4.8.1.
