### PR TITLE
Add failing test for edges exceeding tx-cache-size

### DIFF
--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -1556,4 +1556,28 @@ public abstract class TitanGraphTest extends TitanGraphTestCommon {
         tx = graph.newTransaction();
         assertEquals(n, Iterables.size(tx.getVertices()));
     }
+
+    @Test
+    public void testEdgesExceedCacheSize() {
+        // Add a vertex with as many edges as the tx-cache-size. (20000 by default)
+        int numEdges = graph.getConfiguration().getTxCacheSize();
+        Vertex parentVertex = graph.addVertex(null);
+        for (int i = 0; i < numEdges; i++) {
+            Vertex childVertex = graph.addVertex(null);
+            parentVertex.addEdge("friend", childVertex);
+        }
+        graph.commit();
+        assertEquals(numEdges, Iterables.size(parentVertex.getEdges(Direction.OUT)));
+
+        // Remove an edge.
+        Edge edge = parentVertex.getEdges(Direction.OUT).iterator().next();
+        edge.remove();
+
+        // Check that getEdges returns one fewer.
+        assertEquals(numEdges - 1, Iterables.size(parentVertex.getEdges(Direction.OUT)));
+
+        // Run the same check one more time.
+        // This fails! (Expected: 19999. Actual: 20000.)
+        assertEquals(numEdges - 1, Iterables.size(parentVertex.getEdges(Direction.OUT)));
+    }
 }


### PR DESCRIPTION
There seems to be buggy behavior when the number of edges on a vertex
exceeds the tx-cache-size number. If you remove an edge from the vertex,
it can reappear when you call getEdges on the vertex. I added a unit
test which demonstrates this.
