### PR TITLE
Added GeoJson support

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
@@ -11,6 +11,9 @@ import com.thinkaurelius.titan.graphdb.database.idhandling.VariableLong;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A generic representation of a geographic shape, which can either be a single point,
@@ -353,6 +356,17 @@ public class Geoshape {
 
         @Override
         public Geoshape convert(Object value) {
+            if(value instanceof Collection) {
+                Collection<Object> c = (Collection) value;
+                List<Double> numbers = c.stream().map(o -> {
+                    if (!(o instanceof Number)) {
+                        throw new IllegalArgumentException("Collections may only contain numbers to create a Geoshape");
+                    }
+                    return ((Number)o).doubleValue();
+                }).collect(Collectors.toList());
+                value = numbers.toArray(new Double[numbers.size()]);
+            }
+
             if (value.getClass().isArray() && (value.getClass().getComponentType().isPrimitive() ||
                     Number.class.isAssignableFrom(value.getClass().getComponentType())) ) {
                 Geoshape shape = null;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geoshape.java
@@ -1,6 +1,7 @@
 package com.thinkaurelius.titan.core.attribute;
 
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Doubles;
 import com.spatial4j.core.context.SpatialContext;
 import com.spatial4j.core.distance.DistanceUtils;
 import com.spatial4j.core.shape.Shape;
@@ -11,8 +12,7 @@ import com.thinkaurelius.titan.graphdb.database.idhandling.VariableLong;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -356,15 +356,13 @@ public class Geoshape {
 
         @Override
         public Geoshape convert(Object value) {
+
+            if(value instanceof Map) {
+                return convertGeoJson(value);
+            }
+
             if(value instanceof Collection) {
-                Collection<Object> c = (Collection) value;
-                List<Double> numbers = c.stream().map(o -> {
-                    if (!(o instanceof Number)) {
-                        throw new IllegalArgumentException("Collections may only contain numbers to create a Geoshape");
-                    }
-                    return ((Number)o).doubleValue();
-                }).collect(Collectors.toList());
-                value = numbers.toArray(new Double[numbers.size()]);
+                value = convertCollection((Collection<Object>) value);
             }
 
             if (value.getClass().isArray() && (value.getClass().getComponentType().isPrimitive() ||
@@ -397,6 +395,84 @@ public class Geoshape {
                 return convert(coords);
             } else return null;
         }
+
+
+        private double[] convertCollection(Collection<Object> c) {
+
+            List<Double> numbers = c.stream().map(o -> {
+                if (!(o instanceof Number)) {
+                    throw new IllegalArgumentException("Collections may only contain numbers to create a Geoshape");
+                }
+                return ((Number) o).doubleValue();
+            }).collect(Collectors.toList());
+            return Doubles.toArray(numbers);
+        }
+
+        private Geoshape convertGeoJson(Object value) {
+            //Note that geoJson is long,lat
+            try {
+                Map<String, Object> map = (Map) value;
+                String type = (String) map.get("type");
+                if("Point".equals(type) || "Circle".equals(type) || "Polygon".equals(type)) {
+                    return convertGeometry(map);
+                }
+                else if("Feature".equals(type)) {
+                    Map<String, Object> geometry = (Map) map.get("geometry");
+                    return convertGeometry(geometry);
+                }
+                throw new IllegalArgumentException("Only Point, Circle, Polygon or feature types are supported");
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException("GeoJSON was unparsable");
+            }
+
+        }
+
+        private Geoshape convertGeometry(Map<String, Object> geometry) {
+            String type = (String) geometry.get("type");
+            List<Object> coordinates = (List) geometry.get("coordinates");
+            //Either this is a single point or a collection of points
+
+            if ("Point".equals(type)) {
+                double[] parsedCoordinates = convertCollection(coordinates);
+                return point(parsedCoordinates[1], parsedCoordinates[0]);
+            } else if ("Circle".equals(type)) {
+                Number radius = (Number) geometry.get("radius");
+                if (radius == null) {
+                    throw new IllegalArgumentException("GeoJSON circles require a radius");
+                }
+                double[] parsedCoordinates = convertCollection(coordinates);
+                return circle(parsedCoordinates[1], parsedCoordinates[0], radius.doubleValue());
+            } else if ("Polygon".equals(type)) {
+                if (coordinates.size() != 4) {
+                    throw new IllegalArgumentException("GeoJSON polygons are only supported if they form a box");
+                }
+                List<double[]> polygon = (List<double[]>) coordinates.stream().map(o -> convertCollection((Collection) o)).collect(Collectors.toList());
+
+                double[] p0 = polygon.get(0);
+                double[] p1 = polygon.get(1);
+                double[] p2 = polygon.get(2);
+                double[] p3 = polygon.get(3);
+
+                //This may be a clockwise or counterclockwise polygon, we have to verify that it is a box
+                if ((p0[0] == p1[0] && p1[1] == p2[1] && p2[0] == p3[0] && p3[1] == p0[1]) ||
+                        (p0[1] == p1[1] && p1[0] == p2[0] && p2[1] == p3[1] && p3[0] == p0[0])) {
+                    return box(min(p0[1], p1[1], p2[1], p3[1]), min(p0[0], p1[0], p2[0], p3[0]), max(p0[1], p1[1], p2[1], p3[1]), max(p0[0], p1[0], p2[0], p3[0]));
+                }
+
+                throw new IllegalArgumentException("GeoJSON polygons are only supported if they form a box");
+            } else {
+                throw new IllegalArgumentException("GeoJSON support is restricted to Point, Circle or Polygon.");
+            }
+        }
+
+        private double min(double... numbers) {
+            return Arrays.stream(numbers).min().getAsDouble();
+        }
+
+        private double max(double... numbers) {
+            return Arrays.stream(numbers).max().getAsDouble();
+        }
+
 
         @Override
         public Geoshape read(ScanBuffer buffer) {

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/attribute/GeoshapeTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/attribute/GeoshapeTest.java
@@ -3,6 +3,8 @@ package com.thinkaurelius.titan.graphdb.attribute;
 import com.thinkaurelius.titan.core.attribute.Geoshape;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 
 /**
@@ -47,6 +49,20 @@ public class GeoshapeTest {
         assertNotSame(c,b);
         System.out.println(c);
         System.out.println(b);
+    }
+
+    @Test
+    public void testParseCollection() {
+        Geoshape.GeoshapeSerializer serializer = new Geoshape.GeoshapeSerializer();
+        assertEquals(Geoshape.point(10, 20), serializer.convert(Arrays.asList(10, 20)));
+        assertEquals(Geoshape.circle(10, 20, 30), serializer.convert(Arrays.asList(10, 20, 30)));
+        assertEquals(Geoshape.box(10, 20, 30, 40), serializer.convert(Arrays.asList(10, 20, 30, 40)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFailParseCollection() {
+        Geoshape.GeoshapeSerializer serializer = new Geoshape.GeoshapeSerializer();
+        serializer.convert(Arrays.asList(10, "Foo"));
     }
 
 }

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/attribute/GeoshapeTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/attribute/GeoshapeTest.java
@@ -1,9 +1,14 @@
 package com.thinkaurelius.titan.graphdb.attribute;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.thinkaurelius.titan.core.attribute.Geoshape;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -15,8 +20,8 @@ public class GeoshapeTest {
 
     @Test
     public void testDistance() {
-        Geoshape p1 = Geoshape.point(37.759,-122.536);
-        Geoshape p2 = Geoshape.point(35.714,-105.938);
+        Geoshape p1 = Geoshape.point(37.759, -122.536);
+        Geoshape p2 = Geoshape.point(35.714, -105.938);
 
         double distance = 1496;
         assertEquals(distance,p1.getPoint().distance(p2.getPoint()),5.0);
@@ -51,6 +56,7 @@ public class GeoshapeTest {
         System.out.println(b);
     }
 
+
     @Test
     public void testParseCollection() {
         Geoshape.GeoshapeSerializer serializer = new Geoshape.GeoshapeSerializer();
@@ -64,5 +70,150 @@ public class GeoshapeTest {
         Geoshape.GeoshapeSerializer serializer = new Geoshape.GeoshapeSerializer();
         serializer.convert(Arrays.asList(10, "Foo"));
     }
+
+
+    @Test
+    public void testGeoJsonPoint() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Point\",\n" +
+                "    \"coordinates\": [20.5, 10.5]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        assertEquals(Geoshape.point(10.5, 20.5), s.convert(json));
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGeoJsonPointUnparseable() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Point\",\n" +
+                "    \"coordinates\": [20.5, \"10.5\"]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        s.convert(json);
+    }
+
+
+    @Test
+    public void testGeoJsonCircle() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Circle\",\n" +
+                "    \"radius\": 30.5, " +
+                "    \"coordinates\": [20.5, 10.5]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        assertEquals(Geoshape.circle(10.5, 20.5, 30.5), s.convert(json));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGeoJsonCircleMissingRadius() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Circle\",\n" +
+                "    \"coordinates\": [20.5, 10.5]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        s.convert(json);
+    }
+
+    @Test
+    public void testGeoJsonPolygon() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Polygon\",\n" +
+                "    \"coordinates\": [[20.5, 10.5],[22.5, 10.5],[22.5, 12.5],[20.5, 12.5]]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        assertEquals(Geoshape.box(10.5, 20.5, 12.5, 22.5), s.convert(json));
+
+        //Try the reverse order points
+        json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Polygon\",\n" +
+                "    \"coordinates\": [[20.5, 12.5],[22.5, 12.5],[22.5, 10.5],[20.5, 10.5]]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        assertEquals(Geoshape.box(10.5, 20.5, 12.5, 22.5), s.convert(json));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGeoJsonPolygonNotBox1() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Polygon\",\n" +
+                "    \"coordinates\": [[20.5, 12.5],[22.5, 12.5],[22.5, 10.5],[20.5, 10.6]]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+        s.convert(json);
+
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGeoJsonPolygonNotBox2() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "  \"type\": \"Feature\",\n" +
+                "  \"geometry\": {\n" +
+                "    \"type\": \"Polygon\",\n" +
+                "    \"coordinates\": [[20.5, 10.5],[22.5, 10.5],[22.5, 12.5]]\n" +
+                "  },\n" +
+                "  \"properties\": {\n" +
+                "    \"name\": \"Dinagat Islands\"\n" +
+                "  }\n" +
+                "}", HashMap.class);
+         s.convert(json);
+
+    }
+
+    @Test
+    public void testGeoJsonGeometry() throws IOException {
+        Geoshape.GeoshapeSerializer s = new Geoshape.GeoshapeSerializer();
+        Map json = new ObjectMapper().readValue("{\n" +
+                "    \"type\": \"Point\",\n" +
+                "    \"coordinates\": [20.5, 10.5]\n" +
+                "}", HashMap.class);
+        assertEquals(Geoshape.point(10.5, 20.5), s.convert(json));
+
+    }
+
+
+
 
 }


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/574

Supports Point, Circle and Polygon (Boxes only)

Also a nice side effect is we can embed GeoJson in GraphSON e.g.

``` json
{
    "variables": {},
    "vertices": [{
        "id": 256,
        "label": "test",
        "type": "vertex",
        "properties": {
            "test": [{
                "id": "jk-74-35x",
                "value": {
                    "type": "Feature",
                    "geometry": {
                        "type": "Point",
                        "coordinates": [125.6, 10.1]
                    },
                    "properties": {
                        "name": "Dinagat Islands"
                    }
                },
                "properties": {}
            }]
        }
    }],
    "edges": []
}
```
