### PR TITLE
Add UUID support

### DIFF
--- a/docs/titanbasics.txt
+++ b/docs/titanbasics.txt
@@ -262,6 +262,7 @@ Titan natively supports the following data types.
 |Decimal		|Number with 3 decimal digits
 |Precision		|Number with 6 decimal digits
 |Geoshape		|Geographic shape like point, circle or box
+|UUID   		|UUID
 |=====
 
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/StandardAttributeHandling.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/StandardAttributeHandling.java
@@ -68,6 +68,7 @@ public class StandardAttributeHandling implements AttributeHandling {
         registerClass(String.class, new StringSerializer()); //supports null serialization
         registerClass(Float.class, new FloatSerializer());
         registerClass(Double.class, new DoubleSerializer());
+        registerClass(UUID.class, new UUIDSerializer());
 
 
         //Arrays (support null serialization)

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/UUIDSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/UUIDSerializer.java
@@ -1,0 +1,41 @@
+package com.thinkaurelius.titan.graphdb.database.serialize.attribute;
+
+import com.google.common.base.Preconditions;
+import com.thinkaurelius.titan.core.attribute.AttributeSerializer;
+import com.thinkaurelius.titan.diskstorage.ScanBuffer;
+import com.thinkaurelius.titan.diskstorage.WriteBuffer;
+
+import java.util.UUID;
+
+/**
+ *  @author Bryn Cooke (bryn.cooke@datastax.com)
+ */
+public class UUIDSerializer implements AttributeSerializer<UUID>  {
+
+    @Override
+    public UUID read(ScanBuffer buffer) {
+        long mostSignificantBits = buffer.getLong();
+        long leastSignificantBits = buffer.getLong();
+        return new UUID(mostSignificantBits, leastSignificantBits);
+    }
+
+    @Override
+    public void write(WriteBuffer buffer, UUID attribute) {
+        buffer.putLong(attribute.getMostSignificantBits());
+        buffer.putLong(attribute.getLeastSignificantBits());
+    }
+
+    @Override
+    public void verifyAttribute(UUID value) {
+
+    }
+
+    @Override
+    public UUID convert(Object value) {
+        Preconditions.checkNotNull(value);
+        if(value instanceof String){
+            return UUID.fromString((String) value);
+        }
+        return null;
+    }
+}

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
@@ -14,6 +14,7 @@ import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.UUID;
 
 import static com.thinkaurelius.titan.diskstorage.es.ElasticSearchIndex.*;
 import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.INDEX_CONF_FILE;
@@ -61,6 +62,9 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
         assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
         assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
         assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
+
+        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
     }
 
     @Test

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
@@ -17,6 +17,8 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -76,6 +78,9 @@ public class LuceneIndexTest extends IndexProviderTest {
         assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
         assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Cmp.EQUAL));
         assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Cmp.NOT_EQUAL));
+
+        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
     }
 
 //    @Override

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
@@ -17,6 +17,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.UUID;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -96,6 +98,9 @@ public class SolrIndexTest extends IndexProviderTest {
         assertFalse(index.supports(of(Double.class), Geo.INTERSECT));
         assertFalse(index.supports(of(Long.class), Text.CONTAINS));
         assertFalse(index.supports(of(Geoshape.class), Geo.DISJOINT));
+
+        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
     }
 
 }

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrRunner.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrRunner.java
@@ -13,7 +13,7 @@ public class SolrRunner {
     protected static final int NUM_SERVERS = 1;
     protected static final String[] COLLECTIONS = new String[] { "store1", "store2", "vertex", "edge", "namev", "namee",
             "composite", "psearch", "esearch", "vsearch", "mi", "mixed", "index1", "index2", "index3",
-            "ecategory", "vcategory", "pcategory", "theIndex", "vertices", "edges" };
+            "ecategory", "vcategory", "pcategory", "theIndex", "vertices", "edges", "uuidIndex" };
 
     protected static final String[] KEY_FIELDS = new String[0];
 

--- a/titan-solr/src/test/resources/solr/core-template/schema.xml
+++ b/titan-solr/src/test/resources/solr/core-template/schema.xml
@@ -245,6 +245,10 @@
                    units="degrees"
 		   prefixTree="geohash"/>
 
+        <!-- UUID field -->
+        <fieldType name="uuid"
+                   class="solr.UUIDField"
+                   indexed="true" />
     </types>
 
 
@@ -338,7 +342,7 @@
         <dynamicField name="*_dt"   type="date"     indexed="true"  stored="true"/>
         <dynamicField name="*_g"    type="geo"      indexed="true"  stored="true"/>
 
-        <!--<dynamicField name="*_guid" type="text"     indexed="true"  stored="true"/>-->
+        <dynamicField name="*_uuid" type="uuid"     indexed="true"  stored="true"/>
         <!--<dynamicField name="*_name" type="text"     indexed="true"  stored="true"/>-->
 
         <dynamicField name="random*" type="random" />

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/UUIDSerializerTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/database/serialize/attribute/UUIDSerializerTest.java
@@ -1,0 +1,38 @@
+package com.thinkaurelius.titan.graphdb.database.serialize.attribute;
+
+import com.thinkaurelius.titan.diskstorage.util.ReadArrayBuffer;
+import com.thinkaurelius.titan.diskstorage.util.WriteByteBuffer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+/**
+ * @author Bryn Cooke (bryn.cooke@datastax.com)
+ */
+public class UUIDSerializerTest {
+
+    @Test
+    public void testRoundTrip() {
+        //Write the UUID
+        UUIDSerializer serializer = new UUIDSerializer();
+        UUID uuid1 = UUID.randomUUID();
+        WriteByteBuffer buffer = new WriteByteBuffer();
+        serializer.write(buffer, uuid1);
+
+        //And read it in again
+        ReadArrayBuffer readBuffer = new ReadArrayBuffer(buffer.getStaticBuffer().getBytes(0, 16));
+        UUID uuid2 = serializer.read(readBuffer);
+
+        Assert.assertEquals(uuid1, uuid2);
+    }
+
+    @Test
+    public void testConvert() {
+        //Write the UUID
+        UUIDSerializer serializer = new UUIDSerializer();
+        UUID parsed = serializer.convert("d320e751-3a9c-48a8-88f5-2c8b455baa5f");
+        Assert.assertEquals(UUID.fromString("d320e751-3a9c-48a8-88f5-2c8b455baa5f"), parsed);
+    }
+
+}


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/887
This request adds a UUID serializer.
Strings and Java UUID objects are supported allowing roundtrip via GSON.
Internally UUIDs are stored as two longs.
