### PR TITLE
Added wildcard support for direct queries in ES

### DIFF
--- a/docs/directindex.txt
+++ b/docs/directindex.txt
@@ -41,6 +41,8 @@ graph.indexQuery("vertexByText","v.text:(farm uncle berry)").vertices()
 
 This query matches all vertices where the text contains any of the three words (grouped by parentheses) and score matches higher the more words are matched in the text.
 
+In addition <<elasticsearch,Elasticsearch>> supports wildcard queries, use "v.\*" or "e.*" in the query string to query if any of the properties on the element match.
+
 Gotchas
 ~~~~~~~
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexFeatures.java
@@ -1,6 +1,7 @@
 package com.thinkaurelius.titan.diskstorage.indexing;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.thinkaurelius.titan.core.schema.Mapping;
@@ -18,16 +19,18 @@ public class IndexFeatures {
     private final boolean supportsDocumentTTL;
     private final Mapping defaultStringMapping;
     private final ImmutableSet<Mapping> supportedStringMappings;
+    private final String wildcardField;
 
     public IndexFeatures(boolean supportsDocumentTTL,
                          Mapping defaultMap,
-                         ImmutableSet<Mapping> supportedMap) {
+                         ImmutableSet<Mapping> supportedMap, String wildcardField) {
         Preconditions.checkArgument(defaultMap!=null || defaultMap!=Mapping.DEFAULT);
         Preconditions.checkArgument(supportedMap!=null && !supportedMap.isEmpty()
                                     && supportedMap.contains(defaultMap));
         this.supportsDocumentTTL = supportsDocumentTTL;
         this.defaultStringMapping = defaultMap;
         this.supportedStringMappings = supportedMap;
+        this.wildcardField = wildcardField;
     }
 
     public boolean supportsDocumentTTL() {
@@ -42,12 +45,16 @@ public class IndexFeatures {
         return supportedStringMappings.contains(map);
     }
 
+    public String getWildcardField() {
+        return wildcardField;
+    }
+
     public static class Builder {
 
         private boolean supportsDocumentTTL = false;
         private Mapping defaultStringMapping = Mapping.TEXT;
         private Set<Mapping> supportedMappings = Sets.newHashSet();
-
+        private String wildcardField = "*";
 
         public Builder supportsDocumentTTL() {
             supportsDocumentTTL=true;
@@ -64,10 +71,14 @@ public class IndexFeatures {
             return this;
         }
 
+        public Builder setWildcardField(String wildcardField) {
+            this.wildcardField = wildcardField;
+            return this;
+        }
 
         public IndexFeatures build() {
             return new IndexFeatures(supportsDocumentTTL, defaultStringMapping,
-                    ImmutableSet.copyOf(supportedMappings));
+                    ImmutableSet.copyOf(supportedMappings), wildcardField);
         }
 
 

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -152,7 +152,7 @@ public class ElasticSearchIndex implements IndexProvider {
             new ConfigNamespace(ES_CREATE_NS, "ext", "Overrides for arbitrary settings applied at index creation", true);
 
     private static final IndexFeatures ES_FEATURES = new IndexFeatures.Builder().supportsDocumentTTL()
-            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.TEXTSTRING, Mapping.STRING).build();
+            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.TEXTSTRING, Mapping.STRING).setWildcardField("_all").build();
 
     public static final int HOST_PORT_DEFAULT = 9300;
 

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -41,6 +41,11 @@ public class BerkeleyElasticsearchTest extends TitanIndexTest {
         return true;
     }
 
+    @Override
+    public boolean supportsWildcardQuery() {
+        return true;
+    }
+
     /**
      * Test {@link com.thinkaurelius.titan.example.GraphOfTheGodsFactory#create(String)}.
      */

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ThriftElasticsearchTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ThriftElasticsearchTest.java
@@ -37,6 +37,11 @@ public class ThriftElasticsearchTest extends TitanIndexTest {
         return true;
     }
 
+    @Override
+    public boolean supportsWildcardQuery() {
+        return true;
+    }
+
     @BeforeClass
     public static void beforeClass() {
         CassandraStorageSetup.startCleanEmbedded();

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/BerkeleyLuceneTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/BerkeleyLuceneTest.java
@@ -33,4 +33,9 @@ public class BerkeleyLuceneTest extends TitanIndexTest {
         //TODO: The query [v.name:"Uncle Berry has a farm"] has an empty result set which indicates that exact string
         //matching inside this query is not supported for some reason. INVESTIGATE!
     }
+
+    @Override
+    public boolean supportsWildcardQuery() {
+        return false;
+    }
 }

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/BerkeleySolrTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/BerkeleySolrTest.java
@@ -25,4 +25,9 @@ public class BerkeleySolrTest extends SolrTitanIndexTest {
         //TODO: set SOLR specific config options
         return config.getConfiguration();
     }
+
+    @Override
+    public boolean supportsWildcardQuery() {
+        return false;
+    }
 }

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/ThriftSolrTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/ThriftSolrTest.java
@@ -57,5 +57,9 @@ public class ThriftSolrTest extends SolrTitanIndexTest {
 
     }
 
+    @Override
+    public boolean supportsWildcardQuery() {
+        return false;
+    }
 
 }


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/920

You can now use v.\* or e.\* in indexQuery if you are using elastic search.

@dalaro Could you do a quick review of the code?
