### PR TITLE
Remove hardcoded version of the SQ Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,11 +322,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>sonar-maven-plugin</artifactId>
-                    <version>2.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>wagon-maven-plugin</artifactId>
                     <version>1.0-beta-4</version>
                 </plugin>
@@ -1031,8 +1026,6 @@
                     <plugin>
                         <groupId>org.codehaus.sonar</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
-                        <version>3.7</version>
-                        <inherited>false</inherited>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1020,15 +1020,6 @@
                 <sonar.jacoco.reportPath>../target/jacoco-combined.exec</sonar.jacoco.reportPath>
                 <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
             </properties>
-            <build>
-                <plugins>
-                    <!-- This binds no goals by default.  The user has to run the sonar:sonar goal for this plugin to do anything. -->
-                    <plugin>
-                        <groupId>org.codehaus.sonar</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
Hardcoding versions of the SQ Maven plugin prevents to analyse the project on future releases of SonarQube. For instance, the analysis of Titan on Nemo (http://nemo.sonarqube.org/dashboard/index?id=com.thinkaurelius.titan%3Atitan) is broken because of this.
