### PR TITLE
Added support for different cardinality indexing in ES.

### DIFF
--- a/docs/elasticsearch.txt
+++ b/docs/elasticsearch.txt
@@ -15,6 +15,7 @@ Titan supports http://elasticsearch.org[Elasticsearch] as an index backend.  Her
 * *Numeric Range*: Supports all numeric comparisons in `Compare`.
 * *Flexible Configuration*: Supports embedded or remote operation, custom transport and discovery, and open-ended settings customization.
 * *TTL*: Supports automatically expiring indexed elements.
+* *Collections*: Supports indexing SET and LIST cardinality properties.
 
 Please see <<version-compat>> for details on what versions of ES will work with Titan.
 

--- a/docs/searchpredicates.txt
+++ b/docs/searchpredicates.txt
@@ -125,4 +125,22 @@ In addition when importing a graph via GraphSON Point may be represented by:
 link:http://geojson.org/[GeoJSON] may be specified as Point, Circle or Polygon. However polygons must form a box.
 Note that unlike the Titan API GeoJSON specifies coordinates as lng lat.
 
+Collections
+~~~~~~~~~~~
+If you are using <<elasticsearch,Elasticsearch>> then you can index properties with SET and LIST cardinality.
+For instance:
+
+[source,java]
+mgmt = g.openManagement();
+PropertyKey nameProperty = mgmt.makePropertyKey("name").dataType(String.class).cardinality(Cardinality.SET).make();
+mgmt.buildIndex("search",Vertex.class).addKey(nameProperty).buildMixedIndex("search");
+//Insert a vertex
+Vertex person = graph.addVertex();
+person.property("name", "Robert");
+person.property("name", "Bob");
+graph.tx().commit();
+//Now query it
+g.V.has("name", "Bob").count().next(); //1
+g.V.has("name", "Robert").count().next(); //1
+
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexFeatures.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.core.schema.Mapping;
 
 import java.util.Arrays;
@@ -20,10 +21,12 @@ public class IndexFeatures {
     private final Mapping defaultStringMapping;
     private final ImmutableSet<Mapping> supportedStringMappings;
     private final String wildcardField;
+    private ImmutableSet<Cardinality> supportedCardinaities;
 
     public IndexFeatures(boolean supportsDocumentTTL,
                          Mapping defaultMap,
-                         ImmutableSet<Mapping> supportedMap, String wildcardField) {
+                         ImmutableSet<Mapping> supportedMap, String wildcardField, ImmutableSet<Cardinality> supportedCardinaities) {
+
         Preconditions.checkArgument(defaultMap!=null || defaultMap!=Mapping.DEFAULT);
         Preconditions.checkArgument(supportedMap!=null && !supportedMap.isEmpty()
                                     && supportedMap.contains(defaultMap));
@@ -31,6 +34,7 @@ public class IndexFeatures {
         this.defaultStringMapping = defaultMap;
         this.supportedStringMappings = supportedMap;
         this.wildcardField = wildcardField;
+        this.supportedCardinaities = supportedCardinaities;
     }
 
     public boolean supportsDocumentTTL() {
@@ -49,11 +53,16 @@ public class IndexFeatures {
         return wildcardField;
     }
 
+    public boolean supportsCardinality(Cardinality cardinality) {
+        return supportedCardinaities.contains(cardinality);
+    }
+
     public static class Builder {
 
         private boolean supportsDocumentTTL = false;
         private Mapping defaultStringMapping = Mapping.TEXT;
         private Set<Mapping> supportedMappings = Sets.newHashSet();
+        private Set<Cardinality> supportedCardinalities = Sets.newHashSet();
         private String wildcardField = "*";
 
         public Builder supportsDocumentTTL() {
@@ -71,6 +80,11 @@ public class IndexFeatures {
             return this;
         }
 
+        public Builder supportsCardinality(Cardinality cardinality) {
+            supportedCardinalities.add(cardinality);
+            return this;
+        }
+
         public Builder setWildcardField(String wildcardField) {
             this.wildcardField = wildcardField;
             return this;
@@ -78,7 +92,7 @@ public class IndexFeatures {
 
         public IndexFeatures build() {
             return new IndexFeatures(supportsDocumentTTL, defaultStringMapping,
-                    ImmutableSet.copyOf(supportedMappings), wildcardField);
+                    ImmutableSet.copyOf(supportedMappings), wildcardField,  ImmutableSet.copyOf(supportedCardinalities));
         }
 
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/StandardKeyInformation.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/StandardKeyInformation.java
@@ -2,6 +2,7 @@ package com.thinkaurelius.titan.diskstorage.indexing;
 
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.core.Cardinality;
+import com.thinkaurelius.titan.core.PropertyKey;
 import com.thinkaurelius.titan.core.schema.Parameter;
 
 /**
@@ -13,17 +14,23 @@ public class StandardKeyInformation implements KeyInformation {
     private final Parameter[] parameters;
     private final Cardinality cardinality;
 
-    public StandardKeyInformation(Class<?> dataType) {
-        this(dataType,new Parameter[0]);
-    }
 
-    public StandardKeyInformation(Class<?> dataType, Parameter... parameters) {
+    public StandardKeyInformation(Class<?> dataType, Cardinality cardinality, Parameter... parameters) {
         Preconditions.checkNotNull(dataType);
         Preconditions.checkNotNull(parameters);
         this.dataType = dataType;
         this.parameters = parameters;
-        this.cardinality = Cardinality.SINGLE;
+        this.cardinality = cardinality;
     }
+
+    public StandardKeyInformation(PropertyKey key, Parameter... parameters) {
+        Preconditions.checkNotNull(key);
+        Preconditions.checkNotNull(parameters);
+        this.dataType = key.dataType();
+        this.parameters = parameters;
+        this.cardinality = key.cardinality();
+    }
+
 
     @Override
     public Class<?> getDataType() {

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -2,11 +2,13 @@ package com.thinkaurelius.titan.diskstorage.es;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.thinkaurelius.titan.core.schema.Mapping;
-import com.thinkaurelius.titan.graphdb.internal.Order;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.Multimap;
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.core.TitanException;
 import com.thinkaurelius.titan.core.attribute.*;
+import com.thinkaurelius.titan.core.schema.Mapping;
 import com.thinkaurelius.titan.diskstorage.*;
 import com.thinkaurelius.titan.diskstorage.configuration.ConfigNamespace;
 import com.thinkaurelius.titan.diskstorage.configuration.ConfigOption;
@@ -14,22 +16,24 @@ import com.thinkaurelius.titan.diskstorage.configuration.Configuration;
 import com.thinkaurelius.titan.diskstorage.indexing.*;
 import com.thinkaurelius.titan.diskstorage.util.DefaultTransaction;
 import com.thinkaurelius.titan.graphdb.configuration.PreInitializeConfigOptions;
-
-import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.*;
-
 import com.thinkaurelius.titan.graphdb.database.serialize.AttributeUtil;
+import com.thinkaurelius.titan.graphdb.internal.Order;
 import com.thinkaurelius.titan.graphdb.query.TitanPredicate;
 import com.thinkaurelius.titan.graphdb.query.condition.*;
-
 import com.thinkaurelius.titan.util.system.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -38,6 +42,7 @@ import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -46,6 +51,7 @@ import org.elasticsearch.index.query.*;
 import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -54,12 +60,16 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.*;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -71,7 +81,7 @@ public class ElasticSearchIndex implements IndexProvider {
     private static final Logger log = LoggerFactory.getLogger(ElasticSearchIndex.class);
 
     private static final String TTL_FIELD = "_ttl";
-    private static final String STRING_MAPPING_SUFFIX = "$STRING";
+    private static final String STRING_MAPPING_SUFFIX = "__STRING";
 
     public static final ImmutableList<String> DATA_SUBDIRS = ImmutableList.of("data", "work", "logs");
 
@@ -153,7 +163,7 @@ public class ElasticSearchIndex implements IndexProvider {
             new ConfigNamespace(ES_CREATE_NS, "ext", "Overrides for arbitrary settings applied at index creation", true);
 
     private static final IndexFeatures ES_FEATURES = new IndexFeatures.Builder().supportsDocumentTTL()
-            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.TEXTSTRING, Mapping.STRING).setWildcardField("_all").build();
+            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.TEXTSTRING, Mapping.STRING).setWildcardField("_all").supportsCardinality(Cardinality.SINGLE).supportsCardinality(Cardinality.LIST).supportsCardinality(Cardinality.SET).build();
 
     public static final int HOST_PORT_DEFAULT = 9300;
 
@@ -453,7 +463,7 @@ public class ElasticSearchIndex implements IndexProvider {
         return AttributeUtil.isString(information.getDataType()) && getStringMapping(information)==Mapping.TEXTSTRING;
     }
 
-    public XContentBuilder getContent(final List<IndexEntry> additions, KeyInformation.StoreRetriever informations, int ttl) throws BackendException {
+    public XContentBuilder getNewDocument(final List<IndexEntry> additions, KeyInformation.StoreRetriever informations, int ttl) throws BackendException {
         Preconditions.checkArgument(ttl>=0);
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
@@ -461,73 +471,78 @@ public class ElasticSearchIndex implements IndexProvider {
             // JSON writes duplicate fields one after another, which forces us
             // at this stage to make de-duplication on the IndexEntry list. We don't want to pay the
             // price map storage on the Mutation level because non of other backends need that.
-            Map<String, IndexEntry> uniq = new HashMap<String, IndexEntry>(additions.size()) {{
-                for (IndexEntry e : additions)
-                    put(e.field, e);
-            }};
 
-            for (IndexEntry add : uniq.values()) {
-                if (add.value instanceof Number) {
-                    if (AttributeUtil.isWholeNumber((Number) add.value)) {
-                        builder.field(add.field, ((Number) add.value).longValue());
-                    } else { //double or float
-                        builder.field(add.field, ((Number) add.value).doubleValue());
-                    }
-                } else if (AttributeUtil.isString(add.value)) {
-                    builder.field(add.field, (String) add.value);
-                    if (hasDualStringMapping(informations.get(add.field))) {
-                        builder.field(getDualMappingName(add.field), (String) add.value);
-                    }
-                } else if (add.value instanceof Geoshape) {
-                    Geoshape shape = (Geoshape) add.value;
-                    if (shape.getType() == Geoshape.Type.POINT) {
-                        Geoshape.Point p = shape.getPoint();
-                        builder.field(add.field, new double[]{p.getLongitude(), p.getLatitude()});
-                    } else throw new UnsupportedOperationException("Geo type is not supported: " + shape.getType());
+            Multimap<String, IndexEntry> uniq = LinkedListMultimap.create();
+            for (IndexEntry e : additions) {
+                uniq.put(e.field, e);
+            }
 
-//                    builder.startObject(add.key);
-//                    switch (shape.getType()) {
-//                        case POINT:
-//                            Geoshape.Point p = shape.getPoint();
-//                            builder.field("type","point");
-//                            builder.field("coordinates",new double[]{p.getLongitude(),p.getLatitude()});
-//                            break;
-//                        case BOX:
-//                        Geoshape.Point southwest = shape.getPoint(0), northeast = shape.getPoint(1);
-//                            builder.field("type","envelope");
-//                            builder.field("coordinates",new double[][]{
-//                                    {southwest.getLongitude(),northeast.getLatitude()},
-//                                    {northeast.getLongitude(),southwest.getLatitude()}});
-//                            break;
-//                        default: throw new UnsupportedOperationException("Geo type is not supported: " + shape.getType());
-//                    }
-//                    builder.endObject();
-                } else if (add.value instanceof Date) {
-                    builder.field(add.field, ((Date) add.value));
-                } else if (add.value instanceof Boolean) {
-                    builder.field(add.field, ((Boolean) add.value));
-                } else if (add.value instanceof UUID) {
-                    builder.field(add.field, add.value.toString());
-                } else throw new IllegalArgumentException("Unsupported type: " + add.value);
+            for (Map.Entry<String, Collection<IndexEntry>> add : uniq.asMap().entrySet()) {
+                KeyInformation keyInformation = informations.get(add.getKey());
+                Object value = null;
+                switch (keyInformation.getCardinality()) {
+                    case SINGLE:
+                        value = convertToEsType(Iterators.getLast(add.getValue().iterator()).value);
+                        break;
+                    case SET:
+                    case LIST:
+                        value = add.getValue().stream().map(v -> convertToEsType(v.value)).collect(Collectors.toList()).toArray();
+                        break;
+                }
+
+
+                builder.field(add.getKey(), value);
+                if (hasDualStringMapping(informations.get(add.getKey())) && keyInformation.getDataType() == String.class) {
+                    builder.field(getDualMappingName(add.getKey()), value);
+                }
+
 
             }
             if (ttl>0) builder.field(TTL_FIELD, TimeUnit.MILLISECONDS.convert(ttl,TimeUnit.SECONDS));
 
             builder.endObject();
+
             return builder;
         } catch (IOException e) {
             throw new PermanentBackendException("Could not write json");
         }
     }
 
+    private static Object convertToEsType(Object value) {
+        if (value instanceof Number) {
+            if (AttributeUtil.isWholeNumber((Number) value)) {
+                return ((Number) value).longValue();
+            } else { //double or float
+                return ((Number) value).doubleValue();
+            }
+        } else if (AttributeUtil.isString(value)) {
+            return value;
+        } else if (value instanceof Geoshape) {
+            Geoshape shape = (Geoshape) value;
+            if (shape.getType() == Geoshape.Type.POINT) {
+                Geoshape.Point p = shape.getPoint();
+                return new double[]{p.getLongitude(), p.getLatitude()};
+            } else throw new UnsupportedOperationException("Geo type is not supported: " + shape.getType());
+
+        } else if (value instanceof Date) {
+            return value;
+        } else if (value instanceof Boolean) {
+            return value;
+        } else if (value instanceof UUID) {
+            return value.toString();
+        } else throw new IllegalArgumentException("Unsupported type: " + value);
+    }
+
     @Override
     public void mutate(Map<String, Map<String, IndexMutation>> mutations, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         BulkRequestBuilder brb = client.prepareBulk();
+
         int bulkrequests = 0;
         try {
             for (Map.Entry<String, Map<String, IndexMutation>> stores : mutations.entrySet()) {
                 String storename = stores.getKey();
                 for (Map.Entry<String, IndexMutation> entry : stores.getValue().entrySet()) {
+
                     String docid = entry.getKey();
                     IndexMutation mutation = entry.getValue();
                     assert mutation.isConsolidated();
@@ -540,16 +555,9 @@ public class ElasticSearchIndex implements IndexProvider {
                             log.trace("Deleting entire document {}", docid);
                             brb.add(new DeleteRequest(indexName, storename, docid));
                         } else {
-                            StringBuilder script = new StringBuilder();
-                            for (String key : Iterables.transform(mutation.getDeletions(),IndexMutation.ENTRY2FIELD_FCT)) {
-                                script.append("ctx._source.remove(\"" + key + "\"); ");
-                                if (hasDualStringMapping(informations.get(storename,key))) {
-                                    script.append("ctx._source.remove(\"" + getDualMappingName(key) + "\"); ");
-                                }
-                                log.trace("Deleting individual field [{}] for document {}", key, docid);
-                            }
-                            brb.add(client.prepareUpdate(indexName, storename, docid).setScript(script.toString(), ScriptService.ScriptType.INLINE));
-                            bulkrequests++;
+                            String script = getDeletionScript(informations, storename, mutation);
+                            brb.add(client.prepareUpdate(indexName, storename, docid).setScript(script, ScriptService.ScriptType.INLINE));
+                            log.trace("Adding script {}", script);
                         }
 
                         bulkrequests++;
@@ -560,16 +568,21 @@ public class ElasticSearchIndex implements IndexProvider {
                         if (mutation.isNew()) { //Index
                             log.trace("Adding entire document {}", docid);
                             brb.add(new IndexRequest(indexName, storename, docid)
-                                    .source(getContent(mutation.getAdditions(), informations.get(storename), ttl)));
+                                    .source(getNewDocument(mutation.getAdditions(), informations.get(storename), ttl)));
+
                         } else {
-                            Preconditions.checkArgument(ttl==0,"Elasticsearch only supports TTL on new documents [%s]",docid);
+                            Preconditions.checkArgument(ttl == 0, "Elasticsearch only supports TTL on new documents [%s]", docid);
+
                             boolean needUpsert = !mutation.hasDeletions();
-                            XContentBuilder builder = getContent(mutation.getAdditions(),informations.get(storename),ttl);
-                            UpdateRequestBuilder update = client.prepareUpdate(indexName, storename, docid).setDoc(builder);
-                            if (needUpsert) update.setUpsert(builder);
-                            log.trace("Updating document {} with upsert {}", docid, needUpsert);
+                            String script = getAdditionScript(informations, storename, mutation);
+                            UpdateRequestBuilder update = client.prepareUpdate(indexName, storename, docid).setScript(script, ScriptService.ScriptType.INLINE);
+                            if (needUpsert) {
+                                XContentBuilder doc = getNewDocument(mutation.getAdditions(), informations.get(storename), ttl);
+                                update.setUpsert(doc);
+                            }
+
                             brb.add(update);
-                            bulkrequests++;
+                            log.trace("Adding script {}", script);
                         }
 
                         bulkrequests++;
@@ -577,11 +590,99 @@ public class ElasticSearchIndex implements IndexProvider {
 
                 }
             }
-            if (bulkrequests > 0) brb.execute().actionGet();
+            if (bulkrequests > 0) {
+                BulkResponse bulkItemResponses = brb.execute().actionGet();
+                if (bulkItemResponses.hasFailures()) {
+                    boolean actualFailure = false;
+                    for(BulkItemResponse response : bulkItemResponses.getItems()) {
+                        //The document may have been deleted, which is OK
+                        if(response.getFailure().getStatus() != RestStatus.NOT_FOUND) {
+                            log.error("Failed to execute ES query {}", response.getFailureMessage());
+                            actualFailure = true;
+                        }
+                    }
+                    if(actualFailure) {
+                        throw new Exception(bulkItemResponses.buildFailureMessage());
+                    }
+                }
+            }
         } catch (Exception e) {
+            log.error("Failed to execute ES query {}", brb.request().timeout(), e);
             throw convert(e);
         }
     }
+
+    private String getDeletionScript(KeyInformation.IndexRetriever informations, String storename, IndexMutation mutation) throws PermanentBackendException {
+        StringBuilder script = new StringBuilder();
+        for (IndexEntry deletion : mutation.getDeletions()) {
+            KeyInformation keyInformation = informations.get(storename).get(deletion.field);
+
+            switch (keyInformation.getCardinality()) {
+                case SINGLE:
+                    script.append("ctx._source.remove(\"" + deletion.field + "\");");
+                    if (hasDualStringMapping(informations.get(storename, deletion.field))) {
+                        script.append("ctx._source.remove(\"" + getDualMappingName(deletion.field) + "\");");
+                    }
+                    break;
+                case SET:
+                case LIST:
+                    String jsValue = convertToJsType(deletion.value);
+                    script.append("def index = ctx._source[\"" + deletion.field + "\"].indexOf(" + jsValue + "); ctx._source[\"" + deletion.field + "\"].remove(index);");
+                    if (hasDualStringMapping(informations.get(storename, deletion.field))) {
+                        script.append("def index = ctx._source[\"" + getDualMappingName(deletion.field) + "\"].indexOf(" + jsValue + "); ctx._source[\"" + getDualMappingName(deletion.field) + "\"].remove(index);");
+                    }
+                    break;
+
+            }
+        }
+        return script.toString();
+    }
+
+    private String getAdditionScript(KeyInformation.IndexRetriever informations, String storename, IndexMutation mutation) throws PermanentBackendException {
+        StringBuilder script = new StringBuilder();
+        for (IndexEntry e : mutation.getAdditions()) {
+            KeyInformation keyInformation = informations.get(storename).get(e.field);
+            switch (keyInformation.getCardinality()) {
+                case SINGLE:
+                    script.append("ctx._source[\"" + e.field + "\"] = " + convertToJsType(e.value) + ";");
+                    if (hasDualStringMapping(keyInformation)) {
+                        script.append("ctx._source[\"" + getDualMappingName(e.field) + "\"] = " + convertToJsType(e.value) + ";");
+                    }
+                    break;
+                case SET:
+                case LIST:
+                    script.append("if(ctx._source[\"" + e.field + "\"] == null) {ctx._source[\"" + e.field + "\"] = []};");
+                    script.append("ctx._source[\"" + e.field + "\"].add(" + convertToJsType(e.value) + ");");
+                    if (hasDualStringMapping(keyInformation)) {
+                        script.append("if(ctx._source[\"" + getDualMappingName(e.field) + "\"] == null) {ctx._source[\"" + e.field + "\"] = []};");
+                        script.append("ctx._source[\"" + getDualMappingName(e.field) + "\"].add(" + convertToJsType(e.value) + ");");
+                    }
+                    break;
+
+            }
+
+        }
+        return script.toString();
+    }
+
+    private static String convertToJsType(Object value) throws PermanentBackendException {
+        try {
+            XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+
+            builder.field("value", convertToEsType(value));
+
+            String s = builder.string();
+            int prefixLength = "{\"value\":".length();
+            int suffixLength = "}".length();
+            String result = s.substring(prefixLength, s.length() - suffixLength);
+            return result;
+        } catch (IOException e) {
+            throw new PermanentBackendException("Could not write json");
+        }
+
+
+    }
+
 
     public void restore(Map<String,Map<String, List<IndexEntry>>> documents, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         BulkRequestBuilder bulk = client.prepareBulk();
@@ -605,7 +706,7 @@ public class ElasticSearchIndex implements IndexProvider {
                         // Add
                         if (log.isTraceEnabled())
                             log.trace("Adding entire document {}", docID);
-                        bulk.add(new IndexRequest(indexName, store, docID).source(getContent(content, informations.get(store), IndexMutation.determineTTL(content))));
+                        bulk.add(new IndexRequest(indexName, store, docID).source(getNewDocument(content, informations.get(store), IndexMutation.determineTTL(content))));
                         requests++;
                     }
                 }
@@ -865,10 +966,12 @@ public class ElasticSearchIndex implements IndexProvider {
 
     @Override
     public void close() throws BackendException {
-        client.close();
+
         if (node != null && !node.isClosed()) {
             node.close();
         }
+        client.close();
+
     }
 
     @Override

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/BerkeleyElasticsearchTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/BerkeleyElasticsearchTest.java
@@ -48,6 +48,11 @@ public class BerkeleyElasticsearchTest extends TitanIndexTest {
         return true;
     }
 
+    @Override
+    protected boolean supportsCollections() {
+        return true;
+    }
+
     /**
      * Test {@link com.thinkaurelius.titan.example.GraphOfTheGodsFactory#create(String)}.
      */

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndexTest.java
@@ -2,6 +2,7 @@ package com.thinkaurelius.titan.diskstorage.es;
 
 import com.google.common.base.Joiner;
 import com.thinkaurelius.titan.StorageSetup;
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.core.schema.Parameter;
 import com.thinkaurelius.titan.core.attribute.*;
 import com.thinkaurelius.titan.diskstorage.BackendException;
@@ -54,28 +55,28 @@ public class ElasticSearchIndexTest extends IndexProviderTest {
 
     @Test
     public void testSupport() {
-        assertTrue(index.supports(of(String.class), Text.CONTAINS));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Text.CONTAINS));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Text.CONTAINS));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Date.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Boolean.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Boolean.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
     }
 
     @Test

--- a/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ThriftElasticsearchTest.java
+++ b/titan-es/src/test/java/com/thinkaurelius/titan/diskstorage/es/ThriftElasticsearchTest.java
@@ -41,6 +41,10 @@ public class ThriftElasticsearchTest extends TitanIndexTest {
     public boolean supportsWildcardQuery() {
         return true;
     }
+    @Override
+    protected boolean supportsCollections() {
+        return true;
+    }
 
     @BeforeClass
     public static void beforeClass() {

--- a/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
+++ b/titan-lucene/src/main/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndex.java
@@ -62,7 +62,7 @@ public class LuceneIndex implements IndexProvider {
     private static final int MAX_STRING_FIELD_LEN = 256;
 
     private static final Version LUCENE_VERSION = Version.LUCENE_4_10_4;
-    private static final IndexFeatures LUCENE_FEATURES = new IndexFeatures.Builder().supportedStringMappings(Mapping.TEXT, Mapping.STRING).build();
+    private static final IndexFeatures LUCENE_FEATURES = new IndexFeatures.Builder().supportedStringMappings(Mapping.TEXT, Mapping.STRING).supportsCardinality(Cardinality.SINGLE).build();
 
     private static final int GEO_MAX_LEVELS = 11;
 
@@ -445,9 +445,11 @@ public class LuceneIndex implements IndexProvider {
 
                 if (titanPredicate == Text.CONTAINS) {
                     value = ((String) value).toLowerCase();
-                    List<String> terms = Text.tokenize((String) value);
-                    TermsFilter termsFilter = new TermsFilter(terms.stream().map(s->new Term(key, s)).collect(Collectors.toList()));
-                    params.addFilter(termsFilter);
+                    BooleanFilter b = new BooleanFilter();
+                    for (String term : Text.tokenize((String)value)) {
+                        b.add(new TermsFilter(new Term(key, term)), BooleanClause.Occur.MUST);
+                    }
+                    params.addFilter(b);
                 } else if (titanPredicate == Text.CONTAINS_PREFIX) {
                     value = ((String) value).toLowerCase();
                     params.addFilter(new PrefixFilter(new Term(key, (String) value)));
@@ -529,7 +531,7 @@ public class LuceneIndex implements IndexProvider {
     public Iterable<RawQuery.Result<String>> query(RawQuery query, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         Query q;
         try {
-            q = new QueryParser(LUCENE_VERSION,"_all",analyzer).parse(query.getQuery());
+            q = new QueryParser("_all",analyzer).parse(query.getQuery());
         } catch (ParseException e) {
             throw new PermanentBackendException("Could not parse raw query: "+query.getQuery(),e);
         }

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/BerkeleyLuceneTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/BerkeleyLuceneTest.java
@@ -38,4 +38,9 @@ public class BerkeleyLuceneTest extends TitanIndexTest {
     public boolean supportsWildcardQuery() {
         return false;
     }
+
+    @Override
+    protected boolean supportsCollections() {
+        return false;
+    }
 }

--- a/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
+++ b/titan-lucene/src/test/java/com/thinkaurelius/titan/diskstorage/lucene/LuceneIndexTest.java
@@ -1,6 +1,7 @@
 package com.thinkaurelius.titan.diskstorage.lucene;
 
 import com.thinkaurelius.titan.StorageSetup;
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.core.schema.Parameter;
 import com.thinkaurelius.titan.core.attribute.*;
 import com.thinkaurelius.titan.diskstorage.BackendException;
@@ -56,43 +57,43 @@ public class LuceneIndexTest extends IndexProviderTest {
     @Test
     public void testSupport() {
         // DEFAULT(=TEXT) support
-        assertTrue(index.supports(of(String.class), Text.CONTAINS));
-        assertTrue(index.supports(of(String.class), Text.CONTAINS_PREFIX));
-        assertFalse(index.supports(of(String.class), Text.CONTAINS_REGEX)); // TODO Not supported yet
-        assertFalse(index.supports(of(String.class), Text.REGEX));
-        assertFalse(index.supports(of(String.class), Text.PREFIX));
-        assertFalse(index.supports(of(String.class), Cmp.EQUAL));
-        assertFalse(index.supports(of(String.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS_PREFIX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS_REGEX)); // TODO Not supported yet
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE), Text.REGEX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE), Text.PREFIX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
         // Same tests as above, except explicitly specifying TEXT instead of relying on DEFAULT
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX)); // TODO Not supported yet
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.PREFIX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Cmp.EQUAL));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_PREFIX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX)); // TODO Not supported yet
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.REGEX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.PREFIX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Cmp.EQUAL));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Cmp.NOT_EQUAL));
 
         // STRING support
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.CONTAINS));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.CONTAINS_PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Cmp.EQUAL));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Cmp.NOT_EQUAL));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.CONTAINS));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.CONTAINS_PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Cmp.EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Date.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Boolean.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Boolean.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
     }
 
 //    @Override

--- a/titan-solr/src/main/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndex.java
+++ b/titan-solr/src/main/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndex.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.graphdb.internal.Order;
 import com.thinkaurelius.titan.core.TitanElement;
 import com.thinkaurelius.titan.core.attribute.*;
@@ -138,7 +139,7 @@ public class SolrIndex implements IndexProvider {
 
 
     private static final IndexFeatures SOLR_FEATURES = new IndexFeatures.Builder().supportsDocumentTTL()
-            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.STRING).build();
+            .setDefaultStringMapping(Mapping.TEXT).supportedStringMappings(Mapping.TEXT, Mapping.STRING).supportsCardinality(Cardinality.SINGLE).build();
 
     private final SolrClient solrClient;
     private final Configuration configuration;
@@ -732,6 +733,10 @@ public class SolrIndex implements IndexProvider {
         Mapping mapping = Mapping.getMapping(information);
         if (mapping!=Mapping.DEFAULT && !AttributeUtil.isString(dataType)) return false;
 
+        if(information.getCardinality() != Cardinality.SINGLE) {
+            return false;
+        }
+
         if (Number.class.isAssignableFrom(dataType)) {
             return titanPredicate instanceof Cmp;
         } else if (dataType == Geoshape.class) {
@@ -758,6 +763,9 @@ public class SolrIndex implements IndexProvider {
 
     @Override
     public boolean supports(KeyInformation information) {
+        if(information.getCardinality() != Cardinality.SINGLE) {
+            return false;
+        }
         Class<?> dataType = information.getDataType();
         Mapping mapping = Mapping.getMapping(information);
         if (Number.class.isAssignableFrom(dataType) || dataType == Geoshape.class || dataType == Date.class || dataType == Boolean.class || dataType == UUID.class) {

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
@@ -1,5 +1,6 @@
 package com.thinkaurelius.titan.diskstorage.solr;
 
+import com.thinkaurelius.titan.core.Cardinality;
 import com.thinkaurelius.titan.core.attribute.Cmp;
 import com.thinkaurelius.titan.core.attribute.Geo;
 import com.thinkaurelius.titan.core.attribute.Geoshape;
@@ -60,59 +61,59 @@ public class SolrIndexTest extends IndexProviderTest {
 
     @Test
     public void testSupport() {
-        assertTrue(index.supports(of(String.class)));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT))));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING))));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping",Mapping.TEXTSTRING))));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT))));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING))));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXTSTRING))));
 
-        assertTrue(index.supports(of(Double.class)));
-        assertFalse(index.supports(of(Double.class, new Parameter("mapping",Mapping.TEXT))));
+        assertTrue(index.supports(of(Double.class, Cardinality.SINGLE)));
+        assertFalse(index.supports(of(Double.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXT))));
 
-        assertTrue(index.supports(of(Long.class)));
-        assertTrue(index.supports(of(Long.class, new Parameter("mapping",Mapping.DEFAULT))));
-        assertTrue(index.supports(of(Integer.class)));
-        assertTrue(index.supports(of(Short.class)));
-        assertTrue(index.supports(of(Byte.class)));
-        assertTrue(index.supports(of(Float.class)));
-        assertTrue(index.supports(of(Geoshape.class)));
-        assertFalse(index.supports(of(Object.class)));
-        assertFalse(index.supports(of(Exception.class)));
+        assertTrue(index.supports(of(Long.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(Long.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.DEFAULT))));
+        assertTrue(index.supports(of(Integer.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(Short.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(Byte.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(Float.class, Cardinality.SINGLE)));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE)));
+        assertFalse(index.supports(of(Object.class, Cardinality.SINGLE)));
+        assertFalse(index.supports(of(Exception.class, Cardinality.SINGLE)));
 
-        assertTrue(index.supports(of(String.class), Text.CONTAINS));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.DEFAULT)), Text.CONTAINS_PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.TEXTSTRING)), Text.REGEX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.TEXT)), Text.CONTAINS));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping", Mapping.DEFAULT)), Text.PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
-        assertTrue(index.supports(of(String.class, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
-        assertFalse(index.supports(of(String.class, new Parameter("mapping",Mapping.TEXTSTRING)), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE), Text.CONTAINS));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.DEFAULT)), Text.CONTAINS_PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXT)), Text.CONTAINS_REGEX));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.TEXTSTRING)), Text.REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXT)), Text.CONTAINS));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.DEFAULT)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.PREFIX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping", Mapping.STRING)), Text.REGEX));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.EQUAL));
+        assertTrue(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.STRING)), Cmp.NOT_EQUAL));
+        assertFalse(index.supports(of(String.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXTSTRING)), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Double.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Double.class), Cmp.GREATER_THAN_EQUAL));
-        assertTrue(index.supports(of(Double.class), Cmp.LESS_THAN));
-        assertTrue(index.supports(of(Double.class, new Parameter("mapping",Mapping.DEFAULT)), Cmp.LESS_THAN));
-        assertFalse(index.supports(of(Double.class, new Parameter("mapping",Mapping.TEXT)), Cmp.LESS_THAN));
-        assertTrue(index.supports(of(Geoshape.class), Geo.WITHIN));
+        assertTrue(index.supports(of(Double.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Double.class, Cardinality.SINGLE), Cmp.GREATER_THAN_EQUAL));
+        assertTrue(index.supports(of(Double.class, Cardinality.SINGLE), Cmp.LESS_THAN));
+        assertTrue(index.supports(of(Double.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.DEFAULT)), Cmp.LESS_THAN));
+        assertFalse(index.supports(of(Double.class, Cardinality.SINGLE, new Parameter("mapping",Mapping.TEXT)), Cmp.LESS_THAN));
+        assertTrue(index.supports(of(Geoshape.class, Cardinality.SINGLE), Geo.WITHIN));
 
-        assertFalse(index.supports(of(Double.class), Geo.INTERSECT));
-        assertFalse(index.supports(of(Long.class), Text.CONTAINS));
-        assertFalse(index.supports(of(Geoshape.class), Geo.DISJOINT));
+        assertFalse(index.supports(of(Double.class, Cardinality.SINGLE), Geo.INTERSECT));
+        assertFalse(index.supports(of(Long.class, Cardinality.SINGLE), Text.CONTAINS));
+        assertFalse(index.supports(of(Geoshape.class, Cardinality.SINGLE), Geo.DISJOINT));
 
-        assertTrue(index.supports(of(Date.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.LESS_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN));
-        assertTrue(index.supports(of(Date.class), Cmp.GREATER_THAN_EQUAL));
-        assertTrue(index.supports(of(Date.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.LESS_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.GREATER_THAN_EQUAL));
+        assertTrue(index.supports(of(Date.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(Boolean.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(Boolean.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(Boolean.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
 
-        assertTrue(index.supports(of(UUID.class), Cmp.EQUAL));
-        assertTrue(index.supports(of(UUID.class), Cmp.NOT_EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.EQUAL));
+        assertTrue(index.supports(of(UUID.class, Cardinality.SINGLE), Cmp.NOT_EQUAL));
     }
 
 }

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrTitanIndexTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrTitanIndexTest.java
@@ -30,6 +30,11 @@ public abstract class SolrTitanIndexTest extends TitanIndexTest {
         return true;
     }
 
+    @Override
+    protected boolean supportsCollections() {
+        return false;
+    }
+
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,TitanIndexTest.INDEX),false);


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/593
ES mutations are now done by script except if it is a new document.
Tests added.
Index.supports is called upon index creation to check if the key information supported. This results in a better error message.

@dalaro Please can you review the code changes.
