### PR TITLE
Tweak the signatures of the internal titan interfaces

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/BaseVertexQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/BaseVertexQuery.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  * @see TitanMultiVertexQuery
  * @author Matthias Br&ouml;cheler (http://www.matthiasb.com)
  */
-public interface BaseVertexQuery<Q extends BaseVertexQuery<Q>> {
+public interface BaseVertexQuery<Q> {
 
     /* ---------------------------------------------------------------
     * Query Specification

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphQuery.java
@@ -15,7 +15,7 @@ import org.apache.tinkerpop.gremlin.structure.Order;
  * @since 0.3.0
  */
 
-public interface TitanGraphQuery<Q extends TitanGraphQuery<Q>> {
+public interface TitanGraphQuery {
 
    /* ---------------------------------------------------------------
     * Query Specification
@@ -31,17 +31,17 @@ public interface TitanGraphQuery<Q extends TitanGraphQuery<Q>> {
      * @param condition
      * @return This query
      */
-    public Q has(String key, TitanPredicate predicate, Object condition);
+    public TitanGraphQuery has(String key, TitanPredicate predicate, Object condition);
 
-    public Q has(String key);
+    public TitanGraphQuery has(String key);
 
-    public Q hasNot(String key);
+    public TitanGraphQuery hasNot(String key);
 
-    public Q has(String key, Object value);
+    public TitanGraphQuery has(String key, Object value);
 
-    public Q hasNot(String key, Object value);
+    public TitanGraphQuery hasNot(String key, Object value);
 
-    public <T extends Comparable<?>> Q interval(String key, T startValue, T endValue);
+    public <T extends Comparable<?>> TitanGraphQuery interval(String key, T startValue, T endValue);
 
     /**
      * Limits the size of the returned result set
@@ -49,7 +49,7 @@ public interface TitanGraphQuery<Q extends TitanGraphQuery<Q>> {
      * @param max The maximum number of results to return
      * @return This query
      */
-    public Q limit(final int max);
+    public TitanGraphQuery limit(final int max);
 
     /**
      * Orders the element results of this query according
@@ -59,7 +59,7 @@ public interface TitanGraphQuery<Q extends TitanGraphQuery<Q>> {
      * @param order the ordering direction
      * @return
      */
-    public Q orderBy(String key, Order order);
+    public TitanGraphQuery orderBy(String key, Order order);
 
 
     /* ---------------------------------------------------------------

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphTransaction.java
@@ -49,7 +49,7 @@ public interface TitanGraphTransaction extends Graph, SchemaManager {
      * @return
      * @see TitanGraph#query()
      */
-    public TitanGraphQuery<? extends TitanGraphQuery> query();
+    public TitanGraphQuery query();
 
     /**
      * Returns a {@link com.thinkaurelius.titan.core.TitanIndexQuery} to query for vertices or edges against the specified indexing backend using

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanVertex.java
@@ -91,7 +91,7 @@ public interface TitanVertex extends TitanElement, Vertex {
      * @return New TitanQuery for this vertex
      * @see TitanVertexQuery
      */
-    public TitanVertexQuery<? extends TitanVertexQuery> query();
+    public TitanVertexQuery query();
 
     /**
      * Checks whether this entity has been loaded into the current transaction and modified.

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanVertexQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanVertexQuery.java
@@ -16,7 +16,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
  * @see BaseVertexQuery
  * @author Matthias Br&ouml;cheler (http://www.matthiasb.com)
  */
-public interface TitanVertexQuery<Q extends TitanVertexQuery<Q>> extends BaseVertexQuery<Q> {
+public interface TitanVertexQuery extends BaseVertexQuery<TitanVertexQuery> {
 
    /* ---------------------------------------------------------------
     * Query Specification (overwrite to merge BaseVertexQuery with Blueprint's VertexQuery)
@@ -24,46 +24,46 @@ public interface TitanVertexQuery<Q extends TitanVertexQuery<Q>> extends BaseVer
     */
 
     @Override
-    public Q adjacent(Vertex vertex);
+    public TitanVertexQuery adjacent(Vertex vertex);
 
     @Override
-    public Q types(String... type);
+    public TitanVertexQuery types(String... type);
 
     @Override
-    public Q types(RelationType... type);
+    public TitanVertexQuery types(RelationType... type);
 
     @Override
-    public Q labels(String... labels);
+    public TitanVertexQuery labels(String... labels);
 
     @Override
-    public Q keys(String... keys);
+    public TitanVertexQuery keys(String... keys);
 
     @Override
-    public Q direction(Direction d);
+    public TitanVertexQuery direction(Direction d);
 
     @Override
-    public Q has(String type, Object value);
+    public TitanVertexQuery has(String type, Object value);
 
     @Override
-    public Q has(String key);
+    public TitanVertexQuery has(String key);
 
     @Override
-    public Q hasNot(String key);
+    public TitanVertexQuery hasNot(String key);
 
     @Override
-    public Q hasNot(String key, Object value);
+    public TitanVertexQuery hasNot(String key, Object value);
 
     @Override
-    public Q has(String key, TitanPredicate predicate, Object value);
+    public TitanVertexQuery has(String key, TitanPredicate predicate, Object value);
 
     @Override
-    public <T extends Comparable<?>> Q interval(String key, T start, T end);
+    public <T extends Comparable<?>> TitanVertexQuery interval(String key, T start, T end);
 
     @Override
-    public Q limit(int limit);
+    public TitanVertexQuery limit(int limit);
 
     @Override
-    public Q orderBy(String key, Order order);
+    public TitanVertexQuery orderBy(String key, Order order);
 
 
     /* ---------------------------------------------------------------

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/computer/VertexProgramScanJob.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/computer/VertexProgramScanJob.java
@@ -1,6 +1,7 @@
 package com.thinkaurelius.titan.graphdb.olap.computer;
 
 import com.google.common.base.Preconditions;
+import com.thinkaurelius.titan.core.BaseVertexQuery;
 import com.thinkaurelius.titan.core.TitanGraph;
 import com.thinkaurelius.titan.core.TitanVertex;
 import com.thinkaurelius.titan.diskstorage.EntryList;
@@ -132,7 +133,7 @@ public class VertexProgramScanJob<M> implements VertexScanJob {
                 TitanVertexStep<Vertex> startStep = (TitanVertexStep<Vertex>)incident.asAdmin().getStartStep();
                 startStep.reverseDirection();
                 QueryContainer.QueryBuilder qb = queries.addQuery();
-                startStep.makeQuery(qb);
+                startStep.makeQuery((BaseVertexQuery)qb);
                 qb.edges();
             }
         }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/job/IndexRepairJob.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/job/IndexRepairJob.java
@@ -181,7 +181,7 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
             IndexType indexType = mgmt.getSchemaVertex(index).asIndexType();
             switch (indexType.getElement()) {
                 case PROPERTY:
-                    addIndexSchemaConstraint(queries.addQuery(),indexType).properties();
+                    addIndexSchemaConstraint((TitanVertexQuery)queries.addQuery(),indexType).properties();
                     break;
                 case VERTEX:
                     queries.addQuery().properties();
@@ -189,7 +189,7 @@ public class IndexRepairJob extends IndexUpdateJob implements VertexScanJob {
                     break;
                 case EDGE:
                     indexType.hasSchemaTypeConstraint();
-                    addIndexSchemaConstraint(queries.addQuery().direction(Direction.OUT),indexType).edges();
+                    addIndexSchemaConstraint((TitanVertexQuery)queries.addQuery().direction(Direction.OUT),indexType).edges();
                     break;
                 default: throw new AssertionError("Unexpected category: " + indexType.getElement());
             }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/GraphCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/GraphCentricQueryBuilder.java
@@ -32,7 +32,7 @@ import java.util.*;
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class GraphCentricQueryBuilder implements TitanGraphQuery<GraphCentricQueryBuilder> {
+public class GraphCentricQueryBuilder implements TitanGraphQuery {
 
     private static final Logger log = LoggerFactory.getLogger(GraphCentricQueryBuilder.class);
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/BaseVertexCentricQueryBuilder.java
@@ -23,7 +23,7 @@ import java.util.*;
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>> implements BaseVertexQuery<Q> {
+public abstract class BaseVertexCentricQueryBuilder<Q> {
 
     private static final String[] NO_TYPES = new String[0];
     private static final List<PredicateCondition<String, TitanRelation>> NO_CONSTRAINTS = ImmutableList.of();
@@ -70,7 +70,6 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
 	 */
 
 
-    @Override
     public Q adjacent(Vertex vertex) {
         Preconditions.checkArgument(vertex!=null && (vertex instanceof TitanVertex),"Not a valid vertex provided for adjacency constraint");
         this.adjacentVertex = (TitanVertex)vertex;
@@ -95,38 +94,31 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
         return getThis();
     }
 
-    @Override
     public Q has(String type, Object value) {
         return addConstraint(type, Cmp.EQUAL, value);
     }
 
-    @Override
     public Q hasNot(String key, Object value) {
         return has(key, Cmp.NOT_EQUAL, value);
     }
 
-    @Override
     public Q has(String key) {
         return has(key, Cmp.NOT_EQUAL, (Object) null);
     }
 
-    @Override
     public Q hasNot(String key) {
         return has(key, Cmp.EQUAL, (Object) null);
     }
 
-    @Override
     public Q has(String key, TitanPredicate predicate, Object value) {
         return addConstraint(key, predicate, value);
     }
 
-    @Override
     public <T extends Comparable<?>> Q interval(String key, T start, T end) {
         addConstraint(key, Cmp.GREATER_THAN_EQUAL, start);
         return addConstraint(key, Cmp.LESS_THAN, end);
     }
 
-    @Override
     public Q types(RelationType... types) {
         String[] ts = new String[types.length];
         for (int i = 0; i < types.length; i++) {
@@ -137,12 +129,10 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
 
 
 
-    @Override
     public Q labels(String... labels) {
         return types(labels);
     }
 
-    @Override
     public Q keys(String... keys) {
         return types(keys);
     }
@@ -151,7 +141,6 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
         return types(type.name());
     }
 
-    @Override
     public Q types(String... types) {
         if (types==null) types = NO_TYPES;
         for (String type : types) Preconditions.checkArgument(StringUtils.isNotBlank(type),"Invalid type: %s",type);
@@ -159,21 +148,18 @@ public abstract class BaseVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>
         return getThis();
     }
 
-    @Override
     public Q direction(Direction d) {
         Preconditions.checkNotNull(d);
         dir = d;
         return getThis();
     }
 
-    @Override
     public Q limit(int limit) {
         Preconditions.checkArgument(limit >= 0);
         this.limit = limit;
         return getThis();
     }
 
-    @Override
     public Q orderBy(String keyName, org.apache.tinkerpop.gremlin.structure.Order order) {
         Preconditions.checkArgument(schemaInspector.containsPropertyKey(keyName),"Provided key does not exist: %s",keyName);
         PropertyKey key = schemaInspector.getPropertyKey(keyName);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/BasicVertexCentricQueryBuilder.java
@@ -32,7 +32,7 @@ import java.util.*;
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q>> extends BaseVertexCentricQueryBuilder<Q> {
+public abstract class BasicVertexCentricQueryBuilder<Q> extends BaseVertexCentricQueryBuilder<Q> {
     @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(BasicVertexCentricQueryBuilder.class);
 
@@ -318,12 +318,10 @@ public abstract class BasicVertexCentricQueryBuilder<Q extends BaseVertexQuery<Q
     private static final int HARD_MAX_LIMIT   = 300000;
 
 
-    @Override
     public QueryDescription describeForEdges() {
         return describe(1, RelationCategory.EDGE);
     }
 
-    @Override
     public QueryDescription describeForProperties() {
         return describe(1,RelationCategory.PROPERTY);
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/VertexCentricQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/vertex/VertexCentricQueryBuilder.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<VertexCentricQueryBuilder> implements TitanVertexQuery<VertexCentricQueryBuilder> {
+public class VertexCentricQueryBuilder extends BasicVertexCentricQueryBuilder<VertexCentricQueryBuilder> implements TitanVertexQuery {
 
     private static final Logger log = LoggerFactory.getLogger(VertexCentricQueryBuilder.class);
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsGraph.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsGraph.java
@@ -155,7 +155,7 @@ public abstract class TitanBlueprintsGraph implements TitanGraph {
     }
 
     @Override
-    public TitanGraphQuery<? extends TitanGraphQuery> query() {
+    public TitanGraphQuery query() {
         return getAutoStartTx().query();
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanGraphStep.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanGraphStep.java
@@ -15,6 +15,7 @@ import org.apache.tinkerpop.gremlin.structure.Order;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -43,7 +44,7 @@ public class TitanGraphStep<E extends Element> extends GraphStep<E> implements H
             }
             for (OrderEntry order : orders) query.orderBy(order.key,order.order);
             if (limit!=BaseQuery.NO_LIMIT) query.limit(limit);
-            return Vertex.class.isAssignableFrom(this.returnClass) ? query.vertices().iterator() : query.edges().iterator();
+            return Vertex.class.isAssignableFrom(this.returnClass) ? (Iterator<E>)query.vertices().iterator() : (Iterator<E>)query.edges().iterator();
         });
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanVertexStep.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanVertexStep.java
@@ -82,7 +82,7 @@ public class TitanVertexStep<E extends Element> extends VertexStep<E> implements
             return (Iterator<E>)multiQueryResults.get(traverser.get()).iterator();
         } else {
             TitanVertexQuery query = makeQuery((TitanTraversalUtil.getTitanVertex(traverser)).query());
-            return (Vertex.class.isAssignableFrom(getReturnClass())) ? query.vertices().iterator() : query.edges().iterator();
+            return (Iterator<E>)((Vertex.class.isAssignableFrom(getReturnClass())) ? query.vertices().iterator() : query.edges().iterator());
         }
     }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphBaseTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphBaseTest.java
@@ -341,11 +341,11 @@ public abstract class TitanGraphBaseTest {
         return Math.round(d*1000.0)/1000.0;
     }
 
-    public static TitanVertex getOnlyVertex(TitanGraphQuery<?> query) {
+    public static TitanVertex getOnlyVertex(TitanGraphQuery query) {
         return (TitanVertex)getOnlyElement(query.vertices());
     }
 
-    public static TitanEdge getOnlyEdge(TitanVertexQuery<?> query) {
+    public static TitanEdge getOnlyEdge(TitanVertexQuery query) {
         return (TitanEdge)getOnlyElement(query.edges());
     }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphIterativeBenchmark.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphIterativeBenchmark.java
@@ -16,6 +16,7 @@ import com.thinkaurelius.titan.diskstorage.util.RecordIterator;
 import com.thinkaurelius.titan.diskstorage.util.StandardBaseTransactionConfig;
 import com.thinkaurelius.titan.diskstorage.util.time.Timestamps;
 import com.thinkaurelius.titan.graphdb.types.StandardEdgeLabelMaker;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
 import java.util.Random;
 import java.util.concurrent.*;

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphPerformanceMemoryTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphPerformanceMemoryTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.commons.math.stat.descriptive.SummaryStatistics;
+import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -121,7 +122,7 @@ public abstract class TitanGraphPerformanceMemoryTest extends TitanGraphBaseTest
                         TitanVertex v = getVertex(tx,"uid", random.nextInt(maxUID) + 1);
                         assertCount(2, v.properties());
                         int count = 0;
-                        for (Edge e : v.bothE().toList()) {
+                        for (Edge e : v.query().edges()) {
                             count++;
                             assertTrue(e.<Integer>value("time") >= 0);
                         }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -4277,7 +4277,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
         v3 = getV(graph,v3);
         assertEquals(445, v3.<Integer>value("uid").intValue());
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = getOnlyEdge(v3.query().direction(Direction.OUT).labels("knows"));
         assertEquals(111, e.<Integer>value("uid").intValue());
         assertEquals(e, getE(graph,e.id()));
         assertEquals(e, getE(graph,e.id().toString()));
@@ -4285,10 +4285,10 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         p.remove();
         v3.property("uid", 353);
 
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = getOnlyEdge(v3.query().direction(Direction.OUT).labels("knows"));
         e.property("uid",222);
 
-        e2 = getOnlyElement(v1.query().direction(Direction.OUT).labels("friend").edges());
+        e2 = getOnlyEdge(v1.query().direction(Direction.OUT).labels("friend"));
         e2.property("uid", 1);
         e2.property("weight", 2.0);
 
@@ -4301,7 +4301,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         v3 = getV(graph,v3.id());
         assertEquals(353, v3.<Integer>value("uid").intValue());
 
-        e = getOnlyElement(v3.query().direction(Direction.OUT).labels("knows").edges());
+        e = getOnlyEdge(v3.query().direction(Direction.OUT).labels("knows"));
         assertEquals(222,e.<Integer>value("uid").intValue());
     }
 
@@ -4684,14 +4684,14 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         assertEquals(86400, d.getLength(TimeUnit.SECONDS));
 
         // get the edge via a vertex
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
+        e1 = getOnlyEdge(v1.query().direction(Direction.OUT).labels("likes"));
         d = e1.value("~ttl");
         assertEquals(86400, d.getLength(TimeUnit.SECONDS));
 
         // returned value of ^ttl is the total time to live since commit, not remaining time
         Thread.sleep(1001);
         graph.tx().rollback();
-        e1 = getOnlyElement(v1.query().direction(Direction.OUT).labels("likes").edges());
+        e1 = getOnlyEdge(v1.query().direction(Direction.OUT).labels("likes"));
         d = e1.value("~ttl");
         assertEquals(86400, d.getLength(TimeUnit.SECONDS));
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanOperationCountingTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanOperationCountingTest.java
@@ -33,6 +33,7 @@ import com.thinkaurelius.titan.graphdb.types.CompositeIndexType;
 import com.thinkaurelius.titan.graphdb.types.IndexType;
 import com.thinkaurelius.titan.testcategory.SerialTests;
 import com.thinkaurelius.titan.util.stats.MetricManager;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
@@ -185,7 +186,7 @@ public abstract class TitanOperationCountingTest extends TitanGraphBaseTest {
             tx = graph.buildTransaction().groupName(metricsPrefix).start();
             v = getOnlyElement(tx.query().has("uid",1).vertices());
             assertEquals(1,v.<Integer>value("uid").intValue());
-            u = getOnlyElement(v.both("knows"));
+            u = getOnlyElement(v.query().labels("knows").vertices());
             e = getOnlyElement(u.query().direction(Direction.IN).labels("knows").edges());
             assertEquals("juju",u.value("name"));
             assertEquals("edge",e.value("name"));
@@ -382,7 +383,7 @@ public abstract class TitanOperationCountingTest extends TitanGraphBaseTest {
         //Check no further locks on read all
         tx = graph.buildTransaction().groupName(metricsPrefix).start();
         v = getV(tx,v);
-        for (VertexProperty p : v.properties().toList()) {
+        for (VertexProperty p : v.query().properties()) {
             assertNotNull(p.value());
             assertNotNull(p.key());
         }


### PR DESCRIPTION
to prevent loss of context when constructing vertex and graph centric queries.

Otherwise multiple method calls on a query results in loss of typing.
Before:

```
Iterator<TitanVertex> it = tx.query().vertices();
Iterator<TitanVertex> it = tx.query().has("test").vertices();//Compile error
Iterator<Object> it = tx.query().has("test").vertices();// :0(
```

After:

```
Iterator<TitanVertex> it = tx.query().has("test").vertices();//OK
```

@mbroecheler @dalaro Consider merging this before making more M8 changes if you think the change is a good idea.
