### PR TITLE
Use TermsFilter for lucene test queries. 

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsTransaction.java
@@ -102,7 +102,7 @@ public abstract class TitanBlueprintsTransaction implements TitanTransaction {
         }
 
         final TitanVertex vertex = addVertex(null,label);
-        ElementHelper.attachProperties(vertex, VertexProperty.Cardinality.list, keyValues);
+        ElementHelper.attachProperties(vertex, VertexProperty.Cardinality.single, keyValues);
         return vertex;
     }
 


### PR DESCRIPTION
This should be faster and also fixes the unit tests.
Revert the default property cardinality to single.
