### PR TITLE
Add a new config option for wait-searcher that defaults to false. 

### DIFF
--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/BerkeleySolrTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/BerkeleySolrTest.java
@@ -22,6 +22,7 @@ public class BerkeleySolrTest extends SolrTitanIndexTest {
         //Add index
         config.set(INDEX_BACKEND,"solr",INDEX);
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getMiniCluster().getZkServer().getZkAddress(), INDEX);
+        config.set(SolrIndex.WAIT_SEARCHER, true, INDEX);
         //TODO: set SOLR specific config options
         return config.getConfiguration();
     }

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrIndexTest.java
@@ -54,7 +54,7 @@ public class SolrIndexTest extends IndexProviderTest {
         ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
 
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getMiniCluster().getZkServer().getZkAddress(), index);
-
+        config.set(SolrIndex.WAIT_SEARCHER, true, index);
         return config.restrictTo(index);
     }
 

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/ThriftSolrTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/ThriftSolrTest.java
@@ -22,7 +22,7 @@ public class ThriftSolrTest extends SolrTitanIndexTest {
                 CassandraStorageSetup.getCassandraThriftConfiguration(ThriftSolrTest.class.getName());
         //Add index
         config.set(SolrIndex.ZOOKEEPER_URL, SolrRunner.getMiniCluster().getZkServer().getZkAddress(), INDEX);
-
+        config.set(SolrIndex.WAIT_SEARCHER, true, INDEX);
         config.set(INDEX_BACKEND,"solr",INDEX);
         //TODO: set SOLR specific config options
         return config.getConfiguration();


### PR DESCRIPTION
Allows unit tests to run without race conditions and other users to run a maximum performance.

https://github.com/thinkaurelius/titan/issues/1022
