### PR TITLE
Allow removing a TTL (#981)

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanManagement.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanManagement.java
@@ -264,7 +264,7 @@ public interface TitanManagement extends TitanConfiguration, SchemaManager {
 
     /**
      * Retrieves the time-to-live for the given {@link TitanSchemaType} as a {@link Duration}.
-     * If none has been explicitly defined, a zero-length {@link Duration} is returned.
+     * If none has been explicitly defined, null is returned.
      *
      * @param type
      * @return
@@ -273,7 +273,9 @@ public interface TitanManagement extends TitanConfiguration, SchemaManager {
 
     /**
      * Sets the time-to-live for the given {@link TitanSchemaType}. The most granular time unit used for TTL values
-     *  is seconds. Any argument will be rounded to seconds if it is more granular than that.
+     * is seconds. Any argument will be rounded to seconds if it is more granular than that.  {@code ttl} must be
+     * either positive or -1.  When {@code ttl} is -1, any existing TTL on {@code type} is removed ("live forever").
+     * Positive {@code ttl} values are interpreted literally.
      *
      * @param type the affected type
      * @param ttl time-to-live

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanManagement.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanManagement.java
@@ -264,7 +264,7 @@ public interface TitanManagement extends TitanConfiguration, SchemaManager {
 
     /**
      * Retrieves the time-to-live for the given {@link TitanSchemaType} as a {@link Duration}.
-     * If none has been explicitly defined, null is returned.
+     * If no TTL has been defined, the returned Duration will be zero-length ("lives forever").
      *
      * @param type
      * @return
@@ -273,9 +273,9 @@ public interface TitanManagement extends TitanConfiguration, SchemaManager {
 
     /**
      * Sets the time-to-live for the given {@link TitanSchemaType}. The most granular time unit used for TTL values
-     * is seconds. Any argument will be rounded to seconds if it is more granular than that.  {@code ttl} must be
-     * either positive or -1.  When {@code ttl} is -1, any existing TTL on {@code type} is removed ("live forever").
-     * Positive {@code ttl} values are interpreted literally.
+     * is seconds. Any argument will be rounded to seconds if it is more granular than that.
+     * The {@code ttl} must be nonnegative.  When {@code ttl} is zero, any existing TTL on {@code type} is removed
+     * ("lives forever"). Positive {@code ttl} values are interpreted literally.
      *
      * @param type the affected type
      * @param ttl time-to-live

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/management/ManagementSystem.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/management/ManagementSystem.java
@@ -1081,7 +1081,10 @@ public class ManagementSystem implements TitanManagement {
         } else {
             throw new IllegalArgumentException("given type does not support TTL: " + type.getClass());
         }
-        return new StandardDuration(ttl, TimeUnit.SECONDS);
+
+        return (-1 == ttl) ?
+                null :
+                new StandardDuration(ttl, TimeUnit.SECONDS);
     }
 
     /**

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeUtil.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeUtil.java
@@ -121,6 +121,6 @@ public class TypeUtil {
     }
 
     public static int getTTL(final SchemaSource schema) {
-        return getTypeModifier(schema, ModifierType.TTL, -1).intValue();
+        return getTypeModifier(schema, ModifierType.TTL, 0).intValue();
     }
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeUtil.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeUtil.java
@@ -121,6 +121,6 @@ public class TypeUtil {
     }
 
     public static int getTTL(final SchemaSource schema) {
-        return getTypeModifier(schema, ModifierType.TTL, 0).intValue();
+        return getTypeModifier(schema, ModifierType.TTL, -1).intValue();
     }
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
@@ -92,7 +92,7 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
         //Remove all system types on the vertex
         for (TitanRelation r : it().query().noPartitionRestriction().system().relations()) {
             RelationType t = r.getType();
-            assert t==BaseLabel.VertexLabelEdge || t==BaseKey.VertexExists;
+            assert t==BaseLabel.VertexLabelEdge || t==BaseKey.VertexExists || t==BaseKey.SchemaDefinitionProperty || t==BaseKey.SchemaCategory || t==BaseKey.SchemaUpdateTime;
             r.remove();
         }
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
@@ -92,7 +92,6 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
         //Remove all system types on the vertex
         for (TitanRelation r : it().query().noPartitionRestriction().system().relations()) {
             RelationType t = r.getType();
-            assert t==BaseLabel.VertexLabelEdge || t==BaseKey.VertexExists || t==BaseKey.SchemaDefinitionProperty || t==BaseKey.SchemaCategory || t==BaseKey.SchemaUpdateTime;
             r.remove();
         }
     }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -4756,7 +4756,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         graph.tx().commit();
 
         // Let the edge die
-        Thread.sleep((long)Math.ceil(initialTTLMillis * 1.25));
+        Thread.sleep((long) Math.ceil(initialTTLMillis * 1.25));
 
         // Edge should be gone
         assertEquals(2, Iterators.size(graph.vertices()));
@@ -4765,7 +4765,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
         // Remove the TTL on the edge label
         mgmt = graph.openManagement();
-        mgmt.setTTL(likes, -1, TimeUnit.SECONDS);
+        mgmt.setTTL(mgmt.getEdgeLabel("likes"), 0, TimeUnit.SECONDS);
         mgmt.commit();
 
         Thread.sleep(1L);
@@ -4796,7 +4796,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
         // Check getTTL on edge label
         mgmt = graph.openManagement();
-        assertNull(mgmt.getTTL(mgmt.getEdgeLabel("likes")));
+        assertEquals(0, mgmt.getTTL(mgmt.getEdgeLabel("likes")).getLength(TimeUnit.NANOSECONDS));
         mgmt.rollback();
     }
 
@@ -4809,7 +4809,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
         // Check getTTL on vertex label
         mgmt = graph.openManagement();
-        assertNull(mgmt.getTTL(mgmt.getVertexLabel("foo")));
+        assertEquals(0, mgmt.getTTL(mgmt.getVertexLabel("foo")).getLength(TimeUnit.NANOSECONDS));
         mgmt.rollback();
     }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -4740,6 +4740,9 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
     @Test
     public void testUnsettingTTL() throws InterruptedException {
+        if (!features.hasCellTTL()) {
+            return;
+        }
 
         int initialTTLMillis = 2000;
 
@@ -4789,6 +4792,10 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
     @Test
     public void testGettingUndefinedEdgeLabelTTL() {
+        if (!features.hasCellTTL()) {
+            return;
+        }
+
         // getTTL should return a null duration on an extant type without a TTL
         mgmt.makeEdgeLabel("likes").make();
         mgmt.commit();
@@ -4802,6 +4809,10 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
     @Test
     public void testGettingUndefinedVertexLabelTTL() {
+        if (!features.hasCellTTL()) {
+            return;
+        }
+
         // getTTL should return a null duration on an extant type without a TTL
         mgmt.makeVertexLabel("foo").make();
         mgmt.commit();


### PR DESCRIPTION
This PR changes `setTTL(type, 0, unit)` to mean: remove any existing TTL on the named type, such that new elements of said type will not automatically expire.  Existing elements of the type may still die by TTL.

The scariest line change in here is probably the assertion deletion in `AbstractVertex.remove`.  That was cleared by Matthias: https://github.com/thinkaurelius/titan/commit/addb1559b976c172d8297361c7e9a9ef3d940749#commitcomment-10968686.
