### PR TITLE
Preconditions causes JSON serialization errors with Gremlin Server

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationIdentifier.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationIdentifier.java
@@ -66,7 +66,6 @@ public final class RelationIdentifier implements Serializable {
     }
 
     public long getInVertexId() {
-        Preconditions.checkState(inVertexId != 0);
         return inVertexId;
     }
 


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/1089

With this fix, the example in the issue succeeds with this JSON result

```
{"requestId":"e905ec1c-7a30-44a3-93c8-fb6a17901349","status":{"message":"","code":200,"attributes":{}},"result":{"data":[{"id":{"outVertexId":4272,"typeId":1029,"relationId":1046,"inVertexId":0,"longRepresentation":[1046,4272,1029]},"value":"jason","label":"name"},{"id":{"outVertexId":8368,"typeId":1029,"relationId":2070,"inVertexId":0,"longRepresentation":[2070,8368,1029]},"value":"david","label":"name"}],"meta":{}}}
```
