### PR TITLE
Renamed the Json to GraphSON.

### DIFF
--- a/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -19,8 +19,8 @@ scriptEngines: {
 serializers:
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0 }
   - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.JsonMessageSerializerGremlinV1d0 }
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.JsonMessageSerializerV1d0 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0 }
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0 }
 processors:
   - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
 metrics: {

--- a/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
+++ b/titan-dist/src/assembly/static/conf/gremlin-server/gremlin-server.yaml
@@ -6,7 +6,7 @@ scriptEvaluationTimeout: 30000
 serializedResponseTimeout: 30000
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {
-  g: conf/gremlin-server/titan-berkeleyje-server.properties}
+  graph: conf/gremlin-server/titan-berkeleyje-server.properties}
 plugins:
   - aurelius.titan
 scriptEngines: {


### PR DESCRIPTION
The Json serializers have been renamed in M9, changed the config file to reflect this. The new serializers go by GraphSON.
gremlin-server will throw warnings without this change. With that said, I think GraphSON is now default and doesn't have to be explicitly set in the configuration. It might be safe to remove these two files.
