### PR TITLE
static predicates for Text and Geo

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geo.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Geo.java
@@ -2,6 +2,7 @@ package com.thinkaurelius.titan.core.attribute;
 
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.graphdb.query.TitanPredicate;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
 
 /**
  * Comparison relations for geographic shapes.
@@ -111,4 +112,15 @@ public enum Geo implements TitanPredicate {
         return true;
     }
 
+    //////////////// statics
+
+    public static <V> P<V> geoIntersect(final V value) {
+        return new P(Geo.INTERSECT, value);
+    }
+    public static <V> P<V> geoDisjoint(final V value) {
+        return new P(Geo.DISJOINT, value);
+    }
+    public static <V> P<V> geoWithin(final V value) {
+        return new P(Geo.WITHIN, value);
+    }
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.thinkaurelius.titan.graphdb.query.TitanPredicate;
 import org.apache.commons.lang.StringUtils;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,5 +196,21 @@ public enum Text implements TitanPredicate {
         return true;
     }
 
+    //////////////// statics
 
+    public static <V> P<V> textContains(final V value) {
+        return new P(Text.CONTAINS, value);
+    }
+    public static <V> P<V> textContainsPrefix(final V value) {
+        return new P(Text.CONTAINS_PREFIX, value);
+    }
+    public static <V> P<V> textContainsRegex(final V value) {
+        return new P(Text.CONTAINS_REGEX, value);
+    }
+    public static <V> P<V> textPrefix(final V value) {
+        return new P(Text.PREFIX, value);
+    }
+    public static <V> P<V> textRegex(final V value) {
+        return new P(Text.REGEX, value);
+    }
 }


### PR DESCRIPTION
TP3 changed the syntax of the has() step between M8 and M9. In M8, there was `has(key,bi-predicate,object)` but in M9, there is only `has(key,predicate)`.

So right now with the latest TP3 master and titan09, you have to do something like this:

``` java
g.V().has('name', new P(CONTAINS, 'jason'))
```

With this PR, you can do a has() query with a bi-predicate like this

``` java
g.V().has('name', textContains('jason'))
```

This PR is based on the statics found in here -- https://github.com/apache/incubator-tinkerpop/blob/master/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/P.java

I'm not clear on what should happen with Cmp.java or Contain.java since they seem to have duplicate function of what P.java already has.
