### PR TITLE
specify version of hppc

### DIFF
--- a/titan-core/pom.xml
+++ b/titan-core/pom.xml
@@ -94,6 +94,7 @@
         <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>hppc</artifactId>
+            <version>0.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.high-scale-lib</groupId>


### PR DESCRIPTION
In a project that depends on titan-core the version of hppc was automatically resolved to 0.7.1 (the latest), which isn't compatible. Fixing it to 0.6.0 should work.
