### PR TITLE
Fix bulk operation error propagation for elasticsearch

### DIFF
--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -681,6 +681,7 @@ public class ElasticSearchIndex implements IndexProvider {
             int prefixLength = "{\"value\":".length();
             int suffixLength = "}".length();
             String result = s.substring(prefixLength, s.length() - suffixLength);
+            result = result.replace("$", "\\$");
             return result;
         } catch (IOException e) {
             throw new PermanentBackendException("Could not write json");

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -602,7 +602,7 @@ public class ElasticSearchIndex implements IndexProvider {
                     boolean actualFailure = false;
                     for(BulkItemResponse response : bulkItemResponses.getItems()) {
                         //The document may have been deleted, which is OK
-                        if(response.getFailure().getStatus() != RestStatus.NOT_FOUND) {
+                        if(response.isFailed() && response.getFailure().getStatus() != RestStatus.NOT_FOUND) {
                             log.error("Failed to execute ES query {}", response.getFailureMessage());
                             actualFailure = true;
                         }


### PR DESCRIPTION
In the event of a failure in a batch of operations, elastic search
appears to return a bulk result (for the failing operation) with
a failure object. However when there is no failure, the failure
object is null. The current handling code for bubbling up possible
exceptions does not account for the case where there are successful
operations in a batch of operations containing a failure, leading
to a NPE. This patch adds a test to demonstrate the issue and adds
a check for failure before examining the bulk result.
