### PR TITLE
Update hppc to 0.7.1 to match TP3's dependency on hppc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </scm>
     <properties>
         <titan.compatible.versions />
-        <tinkerpop.version>3.0.0-SNAPSHOT</tinkerpop.version>
+        <tinkerpop.version>3.0.0-incubating</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <mrunit.version>1.1.0</mrunit.version>
         <cassandra.version>2.0.8</cassandra.version>
@@ -916,7 +916,7 @@
             <dependency>
                 <groupId>com.carrotsearch</groupId>
                 <artifactId>hppc</artifactId>
-                <version>0.6.0</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.carrotsearch.randomizedtesting</groupId>

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/EdgeSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/EdgeSerializer.java
@@ -1,8 +1,8 @@
 package com.thinkaurelius.titan.graphdb.database;
 
 import com.carrotsearch.hppc.LongArrayList;
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
-import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.LongObjectHashMap;
+import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.core.*;
@@ -73,7 +73,7 @@ public class EdgeSerializer implements RelationReader {
     public RelationCache parseRelation(Entry data, boolean excludeProperties, TypeInspector tx) {
         ReadBuffer in = data.asReadBuffer();
 
-        LongObjectOpenHashMap properties = excludeProperties ? null : new LongObjectOpenHashMap(4);
+        LongObjectHashMap properties = excludeProperties ? null : new LongObjectHashMap(4);
         RelationTypeParse typeAndDir = IDHandler.readRelationType(in);
 
         long typeId = typeAndDir.typeId;
@@ -165,7 +165,7 @@ public class EdgeSerializer implements RelationReader {
         return new RelationCache(dir, typeId, relationId, other, properties);
     }
 
-    private void readInlineTypes(long[] keyIds, LongObjectOpenHashMap properties, ReadBuffer in, TypeInspector tx, InlineType inlineType) {
+    private void readInlineTypes(long[] keyIds, LongObjectHashMap properties, ReadBuffer in, TypeInspector tx, InlineType inlineType) {
         for (long keyId : keyIds) {
             PropertyKey keyType = tx.getExistingPropertyKey(keyId);
             Object value = readInline(in, keyType, inlineType);
@@ -288,7 +288,7 @@ public class EdgeSerializer implements RelationReader {
         writeInlineTypes(signature, relation, out, tx, InlineType.SIGNATURE);
 
         //Write remaining properties
-        LongSet writtenTypes = new LongOpenHashSet(sortKey.length + signature.length);
+        LongSet writtenTypes = new LongHashSet(sortKey.length + signature.length);
         if (sortKey.length > 0 || signature.length > 0) {
             for (long id : sortKey) writtenTypes.add(id);
             for (long id : signature) writtenTypes.add(id);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationCache.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationCache.java
@@ -1,6 +1,6 @@
 package com.thinkaurelius.titan.graphdb.relations;
 
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.carrotsearch.hppc.cursors.LongObjectCursor;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 
@@ -14,16 +14,16 @@ import java.util.*;
  */
 public class RelationCache implements Iterable<LongObjectCursor<Object>> {
 
-    private static final LongObjectOpenHashMap<Object> EMPTY = new LongObjectOpenHashMap<Object>(0);
+    private static final LongObjectHashMap<Object> EMPTY = new LongObjectHashMap<Object>(0);
 
     public final Direction direction;
     public final long typeId;
     public final long relationId;
     private final Object other;
-    private final LongObjectOpenHashMap<Object> properties;
+    private final LongObjectHashMap<Object> properties;
 
     public RelationCache(final Direction direction, final long typeId, final long relationId,
-                         final Object other, final LongObjectOpenHashMap<Object> properties) {
+                         final Object other, final LongObjectHashMap<Object> properties) {
         this.direction = direction;
         this.typeId = typeId;
         this.relationId = relationId;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
@@ -1,16 +1,16 @@
 package com.thinkaurelius.titan.util.datastructures;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.IntIntHashMap;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
 import java.util.Iterator;
 
 /**
- * Implementation of {@link IntSet} against {@link IntIntOpenHashMap}.
+ * Implementation of {@link IntSet} against {@link IntIntHashMap}.
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class IntHashSet extends IntIntOpenHashMap implements IntSet {
+public class IntHashSet extends IntIntHashMap implements IntSet {
 
     private static final long serialVersionUID = -7297353805905443841L;
     private static final int defaultValue = 1;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/stats/IntegerDoubleFrequency.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/stats/IntegerDoubleFrequency.java
@@ -3,7 +3,7 @@ package com.thinkaurelius.titan.util.stats;
 
 import com.carrotsearch.hppc.IntCollection;
 import com.carrotsearch.hppc.IntDoubleMap;
-import com.carrotsearch.hppc.IntDoubleOpenHashMap;
+import com.carrotsearch.hppc.IntDoubleHashMap;
 
 /**
  * Count relative integer frequencies
@@ -16,7 +16,7 @@ public class IntegerDoubleFrequency {
     private double total;
 
     public IntegerDoubleFrequency() {
-        counts = new IntDoubleOpenHashMap();
+        counts = new IntDoubleHashMap();
         total = 0;
     }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/TestByteBuffer.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/TestByteBuffer.java
@@ -1,7 +1,7 @@
 package com.thinkaurelius.titan;
 
 import com.carrotsearch.hppc.LongObjectMap;
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -66,7 +66,7 @@ public class TestByteBuffer {
     }
 
     private static long testByte() {
-        LongObjectMap<ConcurrentSkipListSet<ByteEntry>> tx = new LongObjectOpenHashMap<ConcurrentSkipListSet<ByteEntry>>(NUM);
+        LongObjectMap<ConcurrentSkipListSet<ByteEntry>> tx = new LongObjectHashMap<ConcurrentSkipListSet<ByteEntry>>(NUM);
         for (int i = 0; i < NUM; i++) {
             tx.put(i, new ConcurrentSkipListSet<ByteEntry>());
         }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/IDAuthorityTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/IDAuthorityTest.java
@@ -1,6 +1,6 @@
 package com.thinkaurelius.titan.diskstorage;
 
-import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.StorageSetup;
@@ -172,7 +172,7 @@ public abstract class IDAuthorityTest {
 
     private void checkBlock(IDBlock block) {
         assertTrue(blockSize<10000);
-        LongSet ids = new LongOpenHashSet((int)blockSize);
+        LongSet ids = new LongHashSet((int)blockSize);
         checkBlock(block,ids);
     }
 
@@ -235,7 +235,7 @@ public abstract class IDAuthorityTest {
         final IDBlockSizer blockSizer = new InnerIDBlockSizer();
         idAuthorities[0].setIDBlockSizer(blockSizer);
         int numTrials = 100;
-        LongSet ids = new LongOpenHashSet((int)blockSize*numTrials);
+        LongSet ids = new LongHashSet((int)blockSize*numTrials);
         long previous = 0;
         for (int i=0;i<numTrials;i++) {
             IDBlock block = idAuthorities[0].getIDBlock(0, 0, GET_ID_BLOCK_TIMEOUT);
@@ -353,7 +353,7 @@ public abstract class IDAuthorityTest {
         es.shutdownNow();
 
         assertEquals(blocksPerThread * CONCURRENCY, blocks.size());
-        LongSet ids = new LongOpenHashSet((int)blockSize*blocksPerThread*CONCURRENCY);
+        LongSet ids = new LongHashSet((int)blockSize*blocksPerThread*CONCURRENCY);
         for (IDBlock block : blocks) checkBlock(block,ids);
     }
 
@@ -397,7 +397,7 @@ public abstract class IDAuthorityTest {
         for (int i = 0; i < numPartitions; i++) {
             ConcurrentLinkedQueue<IDBlock> list = ids.get(i);
             assertEquals(numAcquisitionsPerThreadPartition * CONCURRENCY, list.size());
-            LongSet idset = new LongOpenHashSet((int)blockSize*list.size());
+            LongSet idset = new LongHashSet((int)blockSize*list.size());
             for (IDBlock block : list) checkBlock(block,idset);
         }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanPartitionGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanPartitionGraphTest.java
@@ -1,7 +1,7 @@
 package com.thinkaurelius.titan.graphdb;
 
 
-import com.carrotsearch.hppc.IntOpenHashSet;
+import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.LongArrayList;
 import com.google.common.collect.*;
@@ -352,7 +352,7 @@ public abstract class TitanPartitionGraphTest extends TitanGraphBaseTest {
         int[] groupDegrees = {10,15,10,17,10,4,7,20,11};
         int numVertices = setupGroupClusters(groupDegrees,batchCommit?CommitMode.BATCH:CommitMode.PER_VERTEX);
 
-        IntSet partitionIds = new IntOpenHashSet(numVertices); //to track the "spread" of partition ids
+        IntSet partitionIds = new IntHashSet(numVertices); //to track the "spread" of partition ids
         for (int i=0;i<groupDegrees.length;i++) {
             TitanVertex g = getOnlyVertex(tx.query().has("groupid","group"+i));
             assertCount(groupDegrees[i],g.edges(Direction.OUT,"contain"));
@@ -458,7 +458,7 @@ public abstract class TitanPartitionGraphTest extends TitanGraphBaseTest {
         int[] groupDegrees = {5,5,5,5,5,5,5,5};
         int numVertices = setupGroupClusters(groupDegrees,CommitMode.PER_VERTEX);
 
-        IntSet partitionIds = new IntOpenHashSet(numVertices); //to track the "spread" of partition ids
+        IntSet partitionIds = new IntHashSet(numVertices); //to track the "spread" of partition ids
         for (int i=0;i<groupDegrees.length;i++) {
             TitanVertex g = getOnlyVertex(tx.query().has("groupid","group"+i));
             int partitionId = -1;

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/PartitionIDRangeTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/PartitionIDRangeTest.java
@@ -1,7 +1,5 @@
 package com.thinkaurelius.titan.graphdb.idmanagement;
 
-import com.carrotsearch.hppc.IntOpenHashSet;
-import com.carrotsearch.hppc.IntSet;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/VertexIDAssignerTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/idmanagement/VertexIDAssignerTest.java
@@ -1,6 +1,6 @@
 package com.thinkaurelius.titan.graphdb.idmanagement;
 
-import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.thinkaurelius.titan.core.TitanFactory;
 import com.thinkaurelius.titan.core.TitanGraph;
@@ -96,8 +96,8 @@ public class VertexIDAssignerTest {
 
     @Test
     public void testIDAssignment() {
-        LongSet vertexIds = new LongOpenHashSet();
-        LongSet relationIds = new LongOpenHashSet();
+        LongSet vertexIds = new LongHashSet();
+        LongSet relationIds = new LongHashSet();
         int totalRelations = 0;
         int totalVertices = 0;
         for (int trial = 0; trial < 10; trial++) {

--- a/titan-test/src/test/java/com/thinkaurelius/titan/util/datastructures/RelationCacheTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/util/datastructures/RelationCacheTest.java
@@ -1,9 +1,8 @@
 package com.thinkaurelius.titan.util.datastructures;
 
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.carrotsearch.hppc.cursors.LongObjectCursor;
 import com.google.common.collect.Iterables;
-import com.thinkaurelius.titan.graphdb.relations.RelationCache;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -24,7 +23,7 @@ public class RelationCacheTest {
     @Test
     public void testMap() {
         int len = 100;
-        LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+        LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
         for (int i = 1; i <= len; i++) {
             map.put(i * 1000, "TestValue " + i);
         }
@@ -50,7 +49,7 @@ public class RelationCacheTest {
 
     @Test
     public void testEmpty() {
-        LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+        LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
         assertEquals(0, map.size());
         assertEquals(0, Iterables.size(map));
     }
@@ -61,7 +60,7 @@ public class RelationCacheTest {
         int iterations = 100000;
         for (int k = 0; k < iterations; k++) {
             int len = random.nextInt(10);
-            LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+            LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
             for (int i = 1; i <= len; i++) {
                 map.put(i * 1000, "TestValue " + i);
             }


### PR DESCRIPTION
HPPC introduced a breaking change to Titan with this commit: https://github.com/carrotsearch/hppc/commit/3fe735b781b6b3f7cf87b205a1dea186b96c8c2e

Latest version conflict resolution in Gradle and Ivy cause Titan 0.9 M2 and Tinkerpop 3.0.0-incubating to be incompatible because of TP3's dependency on HPPC 0.7.1

Also contained in this PR is a change in Tinkerpop's version from 3.0.0-SNAPSHOT to 3.0.0-incubating now that it has been released.
