### PR TITLE
Guava 18 and HPPC 0.7 compatibility updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -858,7 +858,7 @@
             <dependency>
                 <groupId>com.carrotsearch</groupId>
                 <artifactId>hppc</artifactId>
-                <version>0.6.0</version>
+                <version>0.7.1</version>
             </dependency>
             <dependency>
                 <groupId>com.carrotsearch.randomizedtesting</groupId>

--- a/titan-core/pom.xml
+++ b/titan-core/pom.xml
@@ -111,6 +111,7 @@
         <dependency>
             <groupId>com.carrotsearch</groupId>
             <artifactId>hppc</artifactId>
+            <version>0.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.stephenc.high-scale-lib</groupId>

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/EdgeSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/EdgeSerializer.java
@@ -1,8 +1,8 @@
 package com.thinkaurelius.titan.graphdb.database;
 
 import com.carrotsearch.hppc.LongArrayList;
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
-import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.LongObjectHashMap;
+import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.core.Cardinality;
@@ -82,7 +82,7 @@ public class EdgeSerializer implements RelationReader {
     public RelationCache parseRelation(Entry data, boolean excludeProperties, TypeInspector tx) {
         ReadBuffer in = data.asReadBuffer();
 
-        LongObjectOpenHashMap properties = excludeProperties ? null : new LongObjectOpenHashMap(4);
+        LongObjectHashMap properties = excludeProperties ? null : new LongObjectHashMap(4);
         EdgeTypeParse typeAndDir = IDHandler.readEdgeType(in);
 
         long typeId = typeAndDir.typeId;
@@ -174,7 +174,7 @@ public class EdgeSerializer implements RelationReader {
         return new RelationCache(dir, typeId, relationId, other, properties);
     }
 
-    private void readInlineTypes(long[] typeids, LongObjectOpenHashMap properties, ReadBuffer in, TypeInspector tx, InlineType inlineType) {
+    private void readInlineTypes(long[] typeids, LongObjectHashMap properties, ReadBuffer in, TypeInspector tx, InlineType inlineType) {
         for (long typeid : typeids) {
             RelationType keyType = tx.getExistingRelationType(typeid);
             Object value = readInline(in, keyType, inlineType);
@@ -308,7 +308,7 @@ public class EdgeSerializer implements RelationReader {
         writeInlineTypes(signature, relation, out, tx, InlineType.SIGNATURE);
 
         //Write remaining properties
-        LongSet writtenTypes = new LongOpenHashSet(sortKey.length + signature.length);
+        LongSet writtenTypes = new LongHashSet(sortKey.length + signature.length);
         if (sortKey.length > 0 || signature.length > 0) {
             for (long id : sortKey) writtenTypes.add(id);
             for (long id : signature) writtenTypes.add(id);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/StandardIDPool.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/StandardIDPool.java
@@ -1,25 +1,17 @@
 package com.thinkaurelius.titan.graphdb.database.idassigner;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.thinkaurelius.titan.core.TitanException;
-import com.thinkaurelius.titan.diskstorage.BackendException;
-import com.thinkaurelius.titan.diskstorage.IDBlock;
 import com.thinkaurelius.titan.core.attribute.Duration;
+import com.thinkaurelius.titan.diskstorage.BackendException;
 import com.thinkaurelius.titan.diskstorage.IDAuthority;
-
+import com.thinkaurelius.titan.diskstorage.IDBlock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -113,7 +105,7 @@ public class StandardIDPool implements IDPool {
     }
 
     private synchronized void waitForIDBlockGetter() throws InterruptedException {
-        Stopwatch sw = new Stopwatch().start();
+        Stopwatch sw = Stopwatch.createStarted();
         if (null != idBlockFuture) {
             try {
                 nextBlock = idBlockFuture.get(renewTimeout.getLength(SCHEDULING_TIME_UNIT), SCHEDULING_TIME_UNIT);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationCache.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/relations/RelationCache.java
@@ -1,6 +1,6 @@
 package com.thinkaurelius.titan.graphdb.relations;
 
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.carrotsearch.hppc.cursors.LongObjectCursor;
 import com.tinkerpop.blueprints.Direction;
 
@@ -14,16 +14,16 @@ import java.util.*;
  */
 public class RelationCache implements Iterable<LongObjectCursor<Object>> {
 
-    private static final LongObjectOpenHashMap<Object> EMPTY = new LongObjectOpenHashMap<Object>(0);
+    private static final LongObjectHashMap<Object> EMPTY = new LongObjectHashMap<Object>(0);
 
     public final Direction direction;
     public final long typeId;
     public final long relationId;
     private final Object other;
-    private final LongObjectOpenHashMap<Object> properties;
+    private final LongObjectHashMap<Object> properties;
 
     public RelationCache(final Direction direction, final long typeId, final long relationId,
-                         final Object other, final LongObjectOpenHashMap<Object> properties) {
+                         final Object other, final LongObjectHashMap<Object> properties) {
         this.direction = direction;
         this.typeId = typeId;
         this.relationId = relationId;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
@@ -1,16 +1,16 @@
 package com.thinkaurelius.titan.util.datastructures;
 
-import com.carrotsearch.hppc.IntIntOpenHashMap;
+import com.carrotsearch.hppc.IntIntHashMap;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
 import java.util.Iterator;
 
 /**
- * Implementation of {@link IntSet} against {@link IntIntOpenHashMap}.
+ * Implementation of {@link IntSet} against {@link IntIntHashMap}.
  *
  * @author Matthias Broecheler (me@matthiasb.com)
  */
-public class IntHashSet extends IntIntOpenHashMap implements IntSet {
+public class IntHashSet extends IntIntHashMap implements IntSet {
 
     private static final long serialVersionUID = -7297353805905443841L;
     private static final int defaultValue = 1;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/stats/IntegerDoubleFrequency.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/stats/IntegerDoubleFrequency.java
@@ -3,7 +3,7 @@ package com.thinkaurelius.titan.util.stats;
 
 import com.carrotsearch.hppc.IntCollection;
 import com.carrotsearch.hppc.IntDoubleMap;
-import com.carrotsearch.hppc.IntDoubleOpenHashMap;
+import com.carrotsearch.hppc.IntDoubleHashMap;
 
 /**
  * Count relative integer frequencies
@@ -16,7 +16,7 @@ public class IntegerDoubleFrequency {
     private double total;
 
     public IntegerDoubleFrequency() {
-        counts = new IntDoubleOpenHashMap();
+        counts = new IntDoubleHashMap();
         total = 0;
     }
 

--- a/titan-test/src/main/java/com/thinkaurelius/titan/TestByteBuffer.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/TestByteBuffer.java
@@ -1,7 +1,7 @@
 package com.thinkaurelius.titan;
 
 import com.carrotsearch.hppc.LongObjectMap;
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -66,7 +66,7 @@ public class TestByteBuffer {
     }
 
     private static long testByte() {
-        LongObjectMap<ConcurrentSkipListSet<ByteEntry>> tx = new LongObjectOpenHashMap<ConcurrentSkipListSet<ByteEntry>>(NUM);
+        LongObjectMap<ConcurrentSkipListSet<ByteEntry>> tx = new LongObjectHashMap<ConcurrentSkipListSet<ByteEntry>>(NUM);
         for (int i = 0; i < NUM; i++) {
             tx.put(i, new ConcurrentSkipListSet<ByteEntry>());
         }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/IDAuthorityTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/IDAuthorityTest.java
@@ -1,26 +1,21 @@
 package com.thinkaurelius.titan.diskstorage;
 
-import com.carrotsearch.hppc.LongOpenHashSet;
+import com.carrotsearch.hppc.LongHashSet;
 import com.carrotsearch.hppc.LongSet;
 import com.google.common.base.Preconditions;
 import com.thinkaurelius.titan.StorageSetup;
 import com.thinkaurelius.titan.core.attribute.Duration;
-import com.thinkaurelius.titan.diskstorage.util.time.StandardDuration;
 import com.thinkaurelius.titan.diskstorage.configuration.Configuration;
 import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
 import com.thinkaurelius.titan.diskstorage.idmanagement.ConflictAvoidanceMode;
 import com.thinkaurelius.titan.diskstorage.idmanagement.ConsistentKeyIDAuthority;
 import com.thinkaurelius.titan.diskstorage.keycolumnvalue.*;
+import com.thinkaurelius.titan.diskstorage.util.time.StandardDuration;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
-
-import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.*;
-import static org.junit.Assert.*;
-
 import com.thinkaurelius.titan.graphdb.database.idassigner.IDBlockSizer;
 import com.thinkaurelius.titan.graphdb.database.idassigner.IDPoolExhaustedException;
 import com.thinkaurelius.titan.testutil.TestGraphConfigs;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -31,13 +26,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+
+import static com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration.*;
+import static org.junit.Assert.*;
 
 /**
  * @author Matthias Broecheler (me@matthiasb.com)
@@ -173,7 +165,7 @@ public abstract class IDAuthorityTest {
 
     private void checkBlock(IDBlock block) {
         assertTrue(blockSize<10000);
-        LongSet ids = new LongOpenHashSet((int)blockSize);
+        LongSet ids = new LongHashSet((int)blockSize);
         checkBlock(block,ids);
     }
 
@@ -236,7 +228,7 @@ public abstract class IDAuthorityTest {
         final IDBlockSizer blockSizer = new InnerIDBlockSizer();
         idAuthorities[0].setIDBlockSizer(blockSizer);
         int numTrials = 100;
-        LongSet ids = new LongOpenHashSet((int)blockSize*numTrials);
+        LongSet ids = new LongHashSet((int)blockSize*numTrials);
         long previous = 0;
         for (int i=0;i<numTrials;i++) {
             IDBlock block = idAuthorities[0].getIDBlock(0, 0, GET_ID_BLOCK_TIMEOUT);
@@ -354,7 +346,7 @@ public abstract class IDAuthorityTest {
         es.shutdownNow();
 
         assertEquals(blocksPerThread * CONCURRENCY, blocks.size());
-        LongSet ids = new LongOpenHashSet((int)blockSize*blocksPerThread*CONCURRENCY);
+        LongSet ids = new LongHashSet((int)blockSize*blocksPerThread*CONCURRENCY);
         for (IDBlock block : blocks) checkBlock(block,ids);
     }
 
@@ -398,7 +390,7 @@ public abstract class IDAuthorityTest {
         for (int i = 0; i < numPartitions; i++) {
             ConcurrentLinkedQueue<IDBlock> list = ids.get(i);
             assertEquals(numAcquisitionsPerThreadPartition * CONCURRENCY, list.size());
-            LongSet idset = new LongOpenHashSet((int)blockSize*list.size());
+            LongSet idset = new LongHashSet((int)blockSize*list.size());
             for (IDBlock block : list) checkBlock(block,idset);
         }
 

--- a/titan-test/src/test/java/com/thinkaurelius/titan/util/datastructures/RelationCacheTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/util/datastructures/RelationCacheTest.java
@@ -1,6 +1,6 @@
 package com.thinkaurelius.titan.util.datastructures;
 
-import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.LongObjectHashMap;
 import com.carrotsearch.hppc.cursors.LongObjectCursor;
 import com.google.common.collect.Iterables;
 import com.thinkaurelius.titan.graphdb.relations.RelationCache;
@@ -24,7 +24,7 @@ public class RelationCacheTest {
     @Test
     public void testMap() {
         int len = 100;
-        LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+        LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
         for (int i = 1; i <= len; i++) {
             map.put(i * 1000, "TestValue " + i);
         }
@@ -50,7 +50,7 @@ public class RelationCacheTest {
 
     @Test
     public void testEmpty() {
-        LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+        LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
         assertEquals(0, map.size());
         assertEquals(0, Iterables.size(map));
     }
@@ -61,7 +61,7 @@ public class RelationCacheTest {
         int iterations = 100000;
         for (int k = 0; k < iterations; k++) {
             int len = random.nextInt(10);
-            LongObjectOpenHashMap<Object> map = new LongObjectOpenHashMap<Object>();
+            LongObjectHashMap<Object> map = new LongObjectHashMap<Object>();
             for (int i = 1; i <= len; i++) {
                 map.put(i * 1000, "TestValue " + i);
             }


### PR DESCRIPTION
We are using updated libraries for ElasticSearch which I think are on the roadmap for Titan to change over to anyway.  
