### PR TITLE
Added missing break in ElasticSearchIndex, that now not all fields are stored analysed and not_analysed

### DIFF
--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -382,6 +382,7 @@ public class ElasticSearchIndex implements IndexProvider {
                         break;
                     case TEXT:
                         //default, do nothing
+                    	break;
                     case TEXTSTRING:
                         mapping.endObject();
                         //add string mapping


### PR DESCRIPTION
Added missing break in ElasticSearchIndex, that now not all fields are stored analysed and not_analysed
This is also contained in version 0.9
