### PR TITLE
add CompactionStrategy options for Cassandra storage configuration

### DIFF
--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/astyanax/AstyanaxStoreManager.java
@@ -439,6 +439,8 @@ public class AstyanaxStoreManager extends AbstractCassandraStoreManager {
                         cl.makeColumnFamilyDefinition()
                                 .setName(name)
                                 .setKeyspace(keySpaceName)
+                                .setCompactionStrategy(storageConfig.get(COMPACTION_STRATEGY))
+                                .setCompactionStrategyOptions(compactionOptions)
                                 .setComparatorType(comparator);
 
                 ImmutableMap.Builder<String, String> compressionOptions = new ImmutableMap.Builder<String, String>();

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
@@ -285,6 +285,12 @@ public class CassandraEmbeddedStoreManager extends AbstractCassandraStoreManager
 
         // Column Family not found; create it
         CFMetaData cfm = new CFMetaData(keyspaceName, columnfamilyName, ColumnFamilyType.Standard, CellNames.fromAbstractType(comparator, true));
+        try {
+            cfm.compactionStrategyClass(CFMetaData.createCompactionStrategy(storageConfig.get(COMPACTION_STRATEGY)));
+            cfm.compactionStrategyOptions(compactionOptions);
+        } catch (ConfigurationException e) {
+            throw new PermanentBackendException("Failed to create column family metadata for " + keyspaceName + ":" + columnfamilyName, e);
+        }
 
         // Hard-coded caching settings
         if (columnfamilyName.startsWith(Backend.EDGESTORE_NAME)) {

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -540,6 +540,8 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
         createColumnFamily.setName(cfName);
         createColumnFamily.setKeyspace(ksName);
         createColumnFamily.setComparator_type(comparator);
+        createColumnFamily.setCompaction_strategy(storageConfig.get(COMPACTION_STRATEGY));
+        createColumnFamily.setCompaction_strategy_options(this.compactionOptions);
 
         ImmutableMap.Builder<String, String> compressionOptions = new ImmutableMap.Builder<String, String>();
 


### PR DESCRIPTION
Allows org.apache.cassandra.db.compaction.LeveledCompactionStrategy to be chosen when the Titan tables are created.
