### PR TITLE
NPE when using repeat step with query.batch=true

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanVertexStep.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/optimize/TitanVertexStep.java
@@ -91,6 +91,11 @@ public class TitanVertexStep<E extends Element> extends VertexStep<E> implements
     @Override
     protected Iterator<E> flatMap(final Traverser.Admin<Vertex> traverser) {
         if (useMultiQuery) {
+            // if this step did not have a start at time of initialization, reinitialize
+            if(multiQueryResults == null) {
+                initialized = false;
+                initialize();
+            }
             assert multiQueryResults != null;
             return (Iterator<E>) multiQueryResults.get(traverser.get()).iterator();
         } else {

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -142,6 +142,7 @@ import static com.thinkaurelius.titan.graphdb.internal.RelationCategory.*;
 import static com.thinkaurelius.titan.testutil.TitanAssert.*;
 import static org.apache.tinkerpop.gremlin.process.traversal.Order.decr;
 import static org.apache.tinkerpop.gremlin.process.traversal.Order.incr;
+import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.out;
 import static org.apache.tinkerpop.gremlin.structure.Direction.*;
 import static org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality.single;
 import static org.junit.Assert.*;
@@ -3448,6 +3449,14 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         metrics = (TraversalMetrics) t.asAdmin().getSideEffects().get("~metrics").get();
         verifyMetrics(metrics.getMetrics(0), true, false);
         verifyMetrics(metrics.getMetrics(1), true, true);
+
+        //Verify that repeat works with multi query
+        t = gts.V().has("id", sid).emit().repeat(out("knows")).profile();
+        assertCount(superV, t);
+        metrics = (TraversalMetrics) t.asAdmin().getSideEffects().get("~metrics").get();
+        verifyMetrics(metrics.getMetrics(0), true, false);
+        /* TODO: this fails because the nested metrics under repeat have empty annotations
+        verifyMetrics(metrics.getMetrics(1), true, true); */
 
         clopen(option(USE_MULTIQUERY), true);
         gts = graph.traversal();


### PR DESCRIPTION
This PR is for issue #1169. I'm pretty new to the interaction between TP3 & the underlying Titan specific steps but I figured I'd take a crack at it. 

After debugging, it appeared that at time of the TitanVertex step's initialization (where the multi query would be traditionally executed if batch==true), the starter vertices were not yet available because of the vertex steps placement nested within the repeat.  I thought about attempting to work my way backwards through the traversal but that seemed problematic.  I instead opted for an additional check in the flatMap to see if the multi query results were really loaded during initialization.  If not, initialization is called again.

One additional thing to note, when putting the test together, it appeared that the TitanVertex step nested within the repeat did not have the expected profiling annotations.  I may have made the incorrect assumption, but thought that this may be a separate, unrelated issue so I commented that test out and added a note.  If this is incorrect, please let me know, or I can also enter another issue if there is something else awry with the profile metrics on nested steps.
