### PR TITLE
Implemented ability for sorting and counting on solr side via 'direct index query" using indexQueryBuilder()

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/IndexQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/IndexQueryBuilder.java
@@ -203,6 +203,22 @@ public class IndexQueryBuilder extends BaseQuery implements TitanIndexQuery {
         });
     }
 
+    // We use this method to calculate total number of vertices, which satisfy the query.
+    public long executeCount() {
+        addParameter(Parameter.of("count", true)); // it is required to set parameter to influence on SolrIndex behavior
+        setPrefixInternal(VERTEX_PREFIX);
+        Preconditions.checkNotNull(indexName);
+        Preconditions.checkNotNull(query);
+        if (tx.hasModifications())
+            log.warn("Modifications in this transaction might not be accurately reflected in this index query: {}",
+                     query);
+        Iterable<RawQuery.Result> results = serializer.executeQuery(this, ElementCategory.VERTEX, tx.getTxHandle(), tx);
+        for (RawQuery.Result result : results) {
+            return (long) result.getScore(); // count is set as score of result
+        }
+        return -1;
+    }
+
     @Override
     public Iterable<Result<Vertex>> vertices() {
         setPrefixInternal(VERTEX_PREFIX);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/IndexQueryBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/IndexQueryBuilder.java
@@ -9,6 +9,7 @@ import com.thinkaurelius.titan.core.schema.Parameter;
 import com.thinkaurelius.titan.core.TitanElement;
 import com.thinkaurelius.titan.core.TitanIndexQuery;
 import com.thinkaurelius.titan.core.TitanProperty;
+import com.thinkaurelius.titan.core.Order;
 import com.thinkaurelius.titan.diskstorage.indexing.RawQuery;
 import com.thinkaurelius.titan.graphdb.database.IndexSerializer;
 import com.thinkaurelius.titan.graphdb.internal.ElementCategory;
@@ -172,6 +173,12 @@ public class IndexQueryBuilder extends BaseQuery implements TitanIndexQuery {
     @Override
     public IndexQueryBuilder addParameters(Parameter... paras) {
         for (Parameter para: paras) addParameter(para);
+        return this;
+    }
+
+    public IndexQueryBuilder orderBy(String field, String order) {
+        Parameter orderByClause = Parameter.of("orderBy", Parameter.of(field, order.equals("asc") ? Order.ASC : Order.DESC));
+        addParameter(orderByClause);
         return this;
     }
 


### PR DESCRIPTION
We faced with performance issue on our project when sorting and counting hundreds of thousands of vertices by different vertex properties and existance of relationships between them. 

To solve the issue we decided to denormalize our data, index all sorting and filtering properties in solr and use 'direct index queries'. However we didn't find a way, how to use those indices for sorting via indexQuery(). Also it was impossible to get 'response.numFound' from solr results to return total number of results to user.

My branch contains required changes, which allow us to sort blazingly fast on the solr side via titan. We are able to return total number of results satisfying the search query as well.
