### PR TITLE
Added MultiQuery GraphProviders and TinkerPop process tests

### DIFF
--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/BerkeleyGraphProvider.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/BerkeleyGraphProvider.java
@@ -16,7 +16,8 @@ public class BerkeleyGraphProvider extends AbstractTitanGraphProvider {
 
     @Override
     public ModifiableConfiguration getTitanConfiguration(String graphName, Class<?> test, String testMethodName) {
-        return BerkeleyStorageSetup.getBerkeleyJEConfiguration(StorageSetup.getHomeDir(graphName)).set(GraphDatabaseConfiguration.IDAUTHORITY_WAIT, Duration.ofMillis(150L));
+        return BerkeleyStorageSetup.getBerkeleyJEConfiguration(StorageSetup.getHomeDir(graphName)).
+                set(GraphDatabaseConfiguration.IDAUTHORITY_WAIT, Duration.ofMillis(150L));
     }
 
     @Override

--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/BerkeleyMultiQueryGraphProvider.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/BerkeleyMultiQueryGraphProvider.java
@@ -1,0 +1,17 @@
+package com.thinkaurelius.titan.blueprints;
+
+import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class BerkeleyMultiQueryGraphProvider extends BerkeleyGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getTitanConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return super.getTitanConfiguration(graphName, test, testMethodName).
+                set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+
+}

--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/process/BerkeleyMultiQueryTitanProcessTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/blueprints/process/BerkeleyMultiQueryTitanProcessTest.java
@@ -1,0 +1,16 @@
+package com.thinkaurelius.titan.blueprints.process;
+
+
+import com.thinkaurelius.titan.blueprints.BerkeleyMultiQueryGraphProvider;
+import com.thinkaurelius.titan.core.TitanGraph;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = BerkeleyMultiQueryGraphProvider.class, graph = TitanGraph.class)
+public class BerkeleyMultiQueryTitanProcessTest {
+}

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/blueprints/thrift/ThriftMultiQueryGraphProvider.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/blueprints/thrift/ThriftMultiQueryGraphProvider.java
@@ -1,0 +1,17 @@
+package com.thinkaurelius.titan.blueprints.thrift;
+
+import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class ThriftMultiQueryGraphProvider extends ThriftGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getTitanConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return super.getTitanConfiguration(graphName, test, testMethodName).
+                set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+
+}

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/blueprints/thrift/process/ThriftMultiQueryProcessTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/blueprints/thrift/process/ThriftMultiQueryProcessTest.java
@@ -1,0 +1,15 @@
+package com.thinkaurelius.titan.blueprints.thrift.process;
+
+import com.thinkaurelius.titan.blueprints.thrift.ThriftMultiQueryGraphProvider;
+import com.thinkaurelius.titan.core.TitanGraph;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = ThriftMultiQueryGraphProvider.class, graph = TitanGraph.class)
+public class ThriftMultiQueryProcessTest {
+}

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/blueprints/HBaseMultiQueryGraphProvider.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/blueprints/HBaseMultiQueryGraphProvider.java
@@ -1,0 +1,16 @@
+package com.thinkaurelius.titan.blueprints;
+
+import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+public class HBaseMultiQueryGraphProvider extends HBaseGraphProvider {
+
+    @Override
+    public ModifiableConfiguration getTitanConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return super.getTitanConfiguration(graphName, test, testMethodName).
+                set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+}

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/blueprints/process/HBaseMultiQueryProcessTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/blueprints/process/HBaseMultiQueryProcessTest.java
@@ -1,0 +1,37 @@
+package com.thinkaurelius.titan.blueprints.process;
+
+import com.thinkaurelius.titan.HBaseStorageSetup;
+import com.thinkaurelius.titan.blueprints.HBaseMultiQueryGraphProvider;
+import com.thinkaurelius.titan.core.TitanGraph;
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+/**
+ * @author Ted Wilmes (twilmes@gmail.com)
+ */
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = HBaseMultiQueryGraphProvider.class, graph = TitanGraph.class)
+public class HBaseMultiQueryProcessTest {
+
+    @BeforeClass
+    public static void startHBase() {
+        try {
+            HBaseStorageSetup.startHBase();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void stopHBase() {
+        // Workaround for https://issues.apache.org/jira/browse/HBASE-10312
+        if (VersionInfo.getVersion().startsWith("0.96"))
+            HBaseStorageSetup.killIfRunning();
+    }
+}

--- a/titan-test/src/test/java/com/thinkaurelius/titan/blueprints/InMemoryMultiQueryGraphProvider.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/blueprints/InMemoryMultiQueryGraphProvider.java
@@ -1,0 +1,15 @@
+package com.thinkaurelius.titan.blueprints;
+
+import com.thinkaurelius.titan.diskstorage.configuration.ModifiableConfiguration;
+import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
+
+/**
+ * Created by twilmes on 06/05/15.
+ */
+public class InMemoryMultiQueryGraphProvider extends InMemoryGraphProvider {
+    @Override
+    public ModifiableConfiguration getTitanConfiguration(String graphName, Class<?> test, String testMethodName) {
+        return super.getTitanConfiguration(graphName, test, testMethodName).
+                set(GraphDatabaseConfiguration.USE_MULTIQUERY, true);
+    }
+}

--- a/titan-test/src/test/java/com/thinkaurelius/titan/blueprints/InMemoryMultiQueryTitanProcessTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/blueprints/InMemoryMultiQueryTitanProcessTest.java
@@ -1,0 +1,11 @@
+package com.thinkaurelius.titan.blueprints;
+
+import com.thinkaurelius.titan.core.TitanGraph;
+import org.apache.tinkerpop.gremlin.GraphProviderClass;
+import org.apache.tinkerpop.gremlin.process.ProcessStandardSuite;
+import org.junit.runner.RunWith;
+
+@RunWith(ProcessStandardSuite.class)
+@GraphProviderClass(provider = InMemoryMultiQueryGraphProvider.class, graph = TitanGraph.class)
+public class InMemoryMultiQueryTitanProcessTest {
+}


### PR DESCRIPTION
I was looking into NPEs that are being thrown when query.batch=true and traversals include a repeat step.  As part of that, @okram suggested that as a first step, I try running the TP process tests against Titan with MultiQuery enabled.  This pull request adds these tests in for each storage option and it should be noted, will result in failures when run due to the aforementioned NPE issue and any other adverse reactions when query.batch=true.  Next step is to work on fixing the batch optimization bug.
