### PR TITLE
Serializer Documentation out of date

### DIFF
--- a/docs/serializer.txt
+++ b/docs/serializer.txt
@@ -2,7 +2,7 @@
 Datatype and Attribute Serializer Configuration
 -----------------------------------------------
 
-Titan supports a number of classes for attribute values on properties. Titan efficiently serializes primitives, primitive arrays, `Date`, `ArrayList` and `HashMap`. By default, Titan allows arbitrary objects as attribute values on properties, but those use default serializer which have significant overhead and may not be as efficient.  
+Titan supports a number of classes for attribute values on properties. Titan efficiently serializes primitives, primitive arrays, and `Date`. By default, Titan allows arbitrary objects as attribute values on properties, but those use default serializer which have significant overhead and may not be as efficient.  
 
 .Serialization Configuration Options
 [cols="4,7,2,2,1", options="header"]

--- a/docs/serializer.txt
+++ b/docs/serializer.txt
@@ -2,7 +2,7 @@
 Datatype and Attribute Serializer Configuration
 -----------------------------------------------
 
-Titan supports a number of classes for attribute values on properties. Titan efficiently serializes primitives, primitive arrays, and `Date`. By default, Titan allows arbitrary objects as attribute values on properties, but those use default serializer which have significant overhead and may not be as efficient.  
+Titan supports a number of classes for attribute values on properties. Titan efficiently serializes primitives, primitive arrays, `Date`, `UUID`, and `Geoshape`. By default, Titan allows arbitrary objects as attribute values on properties, but those use default serializer which have significant overhead and may not be as efficient.  
 
 .Serialization Configuration Options
 [cols="4,7,2,2,1", options="header"]


### PR DESCRIPTION
The documentation for serializers is out of date, Titan 1.0 appears to not support automatic serialization of HashMap or ArrayList. 

More than happy to change the phrasing here if you want, just wanted to get the misinformation out of there.
