### PR TITLE
@Override annotation should be used where necessary

### DIFF
--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyFixedLengthKCVSTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyFixedLengthKCVSTest.java
@@ -13,11 +13,13 @@ import java.util.concurrent.ExecutionException;
 
 public class BerkeleyFixedLengthKCVSTest extends KeyColumnValueStoreTest {
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         BerkeleyJEStoreManager sm = new BerkeleyJEStoreManager(BerkeleyStorageSetup.getBerkeleyJEConfiguration());
         return new OrderedKeyValueStoreManagerAdapter(sm, ImmutableMap.of(storeName, 8));
     }
 
+    @Override
     @Test
     public void testGetKeysWithKeyRange() throws Exception {
         super.testGetKeysWithKeyRange();

--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyLogTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyLogTest.java
@@ -9,6 +9,7 @@ import com.thinkaurelius.titan.diskstorage.log.KCVSLogTest;
 
 public class BerkeleyLogTest extends KCVSLogTest {
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         BerkeleyJEStoreManager sm = new BerkeleyJEStoreManager(BerkeleyStorageSetup.getBerkeleyJEConfiguration());
         return new OrderedKeyValueStoreManagerAdapter(sm);

--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyVariableLengthKCVSTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyVariableLengthKCVSTest.java
@@ -12,11 +12,13 @@ import java.util.concurrent.ExecutionException;
 
 public class BerkeleyVariableLengthKCVSTest extends KeyColumnValueStoreTest {
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         BerkeleyJEStoreManager sm = new BerkeleyJEStoreManager(BerkeleyStorageSetup.getBerkeleyJEConfiguration());
         return new OrderedKeyValueStoreManagerAdapter(sm);
     }
 
+    @Override
     @Test
     public void testGetKeysWithKeyRange() throws Exception {
         super.testGetKeysWithKeyRange();

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
@@ -290,6 +290,7 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
      */
     public abstract Map<String, String> getCompressionOptions(String cf) throws BackendException;
 
+    @Override
     public String getName() {
         return getClass().getSimpleName() + keySpaceName;
     }

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/embedded/CassandraEmbeddedStoreManager.java
@@ -131,6 +131,7 @@ public class CassandraEmbeddedStoreManager extends AbstractCassandraStoreManager
      * {@link StorageService#getLocalPrimaryRanges(String)} returns a raw
      * (unparameterized) type.
      */
+    @Override
     public List<KeyRange> getLocalKeyPartition() throws BackendException {
         ensureKeyspaceExists(keySpaceName);
 

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -369,6 +369,7 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
      *
      * @throws com.thinkaurelius.titan.diskstorage.BackendException if any checked Thrift or UnknownHostException is thrown in the body of this method
      */
+    @Override
     public void clearStorage() throws BackendException {
         openStores.clear();
         final String lp = "ClearStorage: "; // "log prefix"

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanGraphTransaction.java
@@ -40,6 +40,7 @@ public interface TitanGraphTransaction extends Graph, SchemaManager {
      * @param vertexLabel the name of the vertex label to use
      * @return a new vertex in the graph created in the context of this transaction
      */
+    @Override
     public TitanVertex addVertex(String vertexLabel);
 
     @Override

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanRelation.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/TitanRelation.java
@@ -33,6 +33,7 @@ public interface TitanRelation extends TitanElement {
      * @param key string identifying a key
      * @return value or list of values associated with key
      */
+    @Override
     public <V> V value(String key);
 
     /**

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/attribute/Text.java
@@ -140,6 +140,7 @@ public enum Text implements TitanPredicate {
             return evaluateRaw(value.toString(),(String)condition);
         }
 
+        @Override
         public boolean evaluateRaw(String value, String regex) {
             return value.matches(regex);
         }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanGraphIndex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/TitanGraphIndex.java
@@ -19,6 +19,7 @@ public interface TitanGraphIndex extends TitanIndex {
      * Returns the name of the index
      * @return
      */
+    @Override
     public String name();
 
     /**

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
@@ -538,6 +538,7 @@ public class Backend implements LockerProvider, AutoCloseable {
                 maxReadTime, indexTx, threadPool);
     }
 
+    @Override
     public synchronized void close() throws BackendException {
         if (!hasAttemptedClose) {
             hasAttemptedClose = true;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/configuration/MixedConfiguration.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/configuration/MixedConfiguration.java
@@ -53,6 +53,7 @@ public class MixedConfiguration extends AbstractConfiguration {
         return result;
     }
 
+    @Override
     public Map<String,Object> getSubset(ConfigNamespace umbrella, String... umbrellaElements) {
         Map<String,Object> result = Maps.newHashMap();
         for (ReadConfiguration config : new ReadConfiguration[]{global,local}) {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/configuration/backend/KCVSConfiguration.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/configuration/backend/KCVSConfiguration.java
@@ -102,6 +102,7 @@ public class KCVSConfiguration implements ConcurrentWriteConfiguration {
         return staticBuffer2Object(result, datatype);
     }
 
+    @Override
     public<O> void set(String key, O value, O expectedValue) {
         set(key,value,expectedValue,true);
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/locking/consistentkey/ExpectedValueCheckingStore.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/locking/consistentkey/ExpectedValueCheckingStore.java
@@ -105,6 +105,7 @@ public class ExpectedValueCheckingStore extends KCVSProxy {
         return store;
     }
 
+    @Override
     protected StoreTransaction unwrapTx(StoreTransaction t) {
         assert null != t;
         assert t instanceof ExpectedValueCheckingTransaction;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/log/util/AbstractMessage.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/log/util/AbstractMessage.java
@@ -37,6 +37,7 @@ public abstract class AbstractMessage implements Message {
         return senderId;
     }
 
+    @Override
     public Instant getTimestamp() {
         return timestamp;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/MetricInstrumentedIterator.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/MetricInstrumentedIterator.java
@@ -58,6 +58,7 @@ public class MetricInstrumentedIterator implements KeyIterator {
     public boolean hasNext() {
         return MetricInstrumentedStore.runWithMetrics(p, null, M_HAS_NEXT,
             new UncheckedCallable<Boolean>() {
+                @Override
                 public Boolean call() {
                     return Boolean.valueOf(iterator.hasNext());
                 }
@@ -69,6 +70,7 @@ public class MetricInstrumentedIterator implements KeyIterator {
     public StaticBuffer next() {
         return MetricInstrumentedStore.runWithMetrics(p, null, M_NEXT,
             new UncheckedCallable<StaticBuffer>() {
+                @Override
                 public StaticBuffer call() {
                     return iterator.next();
                 }
@@ -80,6 +82,7 @@ public class MetricInstrumentedIterator implements KeyIterator {
     public void close() throws IOException {
         MetricInstrumentedStore.runWithMetrics(p, null, M_CLOSE,
             new IOCallable<Void>() {
+                @Override
                 public Void call() throws IOException {
                     iterator.close();
                     return null;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/MetricInstrumentedStore.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/MetricInstrumentedStore.java
@@ -88,6 +88,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
     public EntryList getSlice(final KeySliceQuery query, final StoreTransaction txh) throws BackendException {
         return runWithMetrics(txh, metricsStoreName, M_GET_SLICE,
             new StorageCallable<EntryList>() {
+                @Override
                 public EntryList call() throws BackendException {
                     EntryList result = backend.getSlice(query, txh);
                     recordSliceMetrics(txh, result);
@@ -103,6 +104,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
                                       final StoreTransaction txh) throws BackendException {
         return runWithMetrics(txh, metricsStoreName, M_GET_SLICE,
             new StorageCallable<Map<StaticBuffer,EntryList>>() {
+                @Override
                 public Map<StaticBuffer,EntryList> call() throws BackendException {
                     Map<StaticBuffer,EntryList> results = backend.getSlice(keys, query, txh);
 
@@ -122,6 +124,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
                        final StoreTransaction txh) throws BackendException {
         runWithMetrics(txh, metricsStoreName, M_MUTATE,
                 new StorageCallable<Void>() {
+                    @Override
                     public Void call() throws BackendException {
                         backend.mutate(key, additions, deletions, txh);
                         return null;
@@ -137,6 +140,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
                             final StoreTransaction txh) throws BackendException {
         runWithMetrics(txh, metricsStoreName, M_ACQUIRE_LOCK,
             new StorageCallable<Void>() {
+                @Override
                 public Void call() throws BackendException {
                     backend.acquireLock(key, column, expectedValue, txh);
                     return null;
@@ -149,6 +153,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
     public KeyIterator getKeys(final KeyRangeQuery query, final StoreTransaction txh) throws BackendException {
         return runWithMetrics(txh, metricsStoreName, M_GET_KEYS,
             new StorageCallable<KeyIterator>() {
+                @Override
                 public KeyIterator call() throws BackendException {
                     KeyIterator ki = backend.getKeys(query, txh);
                     if (txh.getConfiguration().hasGroupName()) {
@@ -165,6 +170,7 @@ public class MetricInstrumentedStore implements KeyColumnValueStore {
     public KeyIterator getKeys(final SliceQuery query, final StoreTransaction txh) throws BackendException {
         return runWithMetrics(txh, metricsStoreName, M_GET_KEYS,
             new StorageCallable<KeyIterator>() {
+                @Override
                 public KeyIterator call() throws BackendException {
                     KeyIterator ki = backend.getKeys(query, txh);
                     if (txh.getConfiguration().hasGroupName()) {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/ReadArrayBuffer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/ReadArrayBuffer.java
@@ -104,42 +104,49 @@ public class ReadArrayBuffer extends StaticArrayBuffer implements ReadBuffer {
 
     //------
 
+    @Override
     public byte[] getBytes(int length) {
         byte[] result = super.getBytes(position,length);
         position += length*BYTE_LEN;
         return result;
     }
 
+    @Override
     public short[] getShorts(int length) {
         short[] result = super.getShorts(position,length);
         position += length*SHORT_LEN;
         return result;
     }
 
+    @Override
     public int[] getInts(int length) {
         int[] result = super.getInts(position,length);
         position += length*INT_LEN;
         return result;
     }
 
+    @Override
     public long[] getLongs(int length) {
         long[] result = super.getLongs(position,length);
         position += length*LONG_LEN;
         return result;
     }
 
+    @Override
     public char[] getChars(int length) {
         char[] result = super.getChars(position,length);
         position += length*CHAR_LEN;
         return result;
     }
 
+    @Override
     public float[] getFloats(int length) {
         float[] result = super.getFloats(position,length);
         position += length*FLOAT_LEN;
         return result;
     }
 
+    @Override
     public double[] getDoubles(int length) {
         double[] result = super.getDoubles(position,length);
         position += length*DOUBLE_LEN;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayBuffer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayBuffer.java
@@ -242,6 +242,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public short[] getShorts(int position, int length) {
         short[] result = new short[length];
         for (int i = 0; i < length; i++) {
@@ -251,6 +252,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public int[] getInts(int position, int length) {
         int[] result = new int[length];
         for (int i = 0; i < length; i++) {
@@ -260,6 +262,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public long[] getLongs(int position, int length) {
         long[] result = new long[length];
         for (int i = 0; i < length; i++) {
@@ -269,6 +272,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public char[] getChars(int position, int length) {
         char[] result = new char[length];
         for (int i = 0; i < length; i++) {
@@ -278,6 +282,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public float[] getFloats(int position, int length) {
         float[] result = new float[length];
         for (int i = 0; i < length; i++) {
@@ -287,6 +292,7 @@ public class StaticArrayBuffer implements StaticBuffer {
         return result;
     }
 
+    @Override
     public double[] getDoubles(int position, int length) {
         double[] result = new double[length];
         for (int i = 0; i < length; i++) {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayEntryList.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayEntryList.java
@@ -161,6 +161,7 @@ public class StaticArrayEntryList extends AbstractList<Entry> implements EntryLi
             caches[currentIndex]=cache;
         }
 
+        @Override
         public boolean hasMetaData() {
             verifyAccess();
             return !metadata.isEmpty();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/UncaughtExceptionLogger.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/UncaughtExceptionLogger.java
@@ -17,26 +17,31 @@ public class UncaughtExceptionLogger implements UncaughtExceptionHandler {
      */
     public static enum UELevel implements UELogLevel {
         TRACE {
+            @Override
             public void dispatch(String message, Throwable t) {
                 log.trace(message, t);
             }
         },
         DEBUG {
+            @Override
             public void dispatch(String message, Throwable t) {
                 log.debug(message, t);
             }
         },
         INFO {
+            @Override
             public void dispatch(String message, Throwable t) {
                 log.info(message, t);
             }
         },
         WARN {
+            @Override
             public void dispatch(String message, Throwable t) {
                 log.warn(message, t);
             }
         },
         ERROR {
+            @Override
             public void dispatch(String message, Throwable t) {
                 log.error(message, t);
             }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/IndexSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/IndexSerializer.java
@@ -401,6 +401,7 @@ public class IndexSerializer {
 
     public static class IndexRecords extends ArrayList<RecordEntry[]> {
 
+        @Override
         public boolean add(RecordEntry[] record) {
             return super.add(Arrays.copyOf(record,record.length));
         }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/RelationQueryCache.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/RelationQueryCache.java
@@ -56,6 +56,7 @@ public class RelationQueryCache implements AutoCloseable {
         return ce.get(dir);
     }
 
+    @Override
     public void close() {
         cache.invalidateAll();
         cache.cleanUp();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/VertexIDAssigner.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/VertexIDAssigner.java
@@ -123,6 +123,7 @@ public class VertexIDAssigner implements AutoCloseable {
         return idManager;
     }
 
+    @Override
     public synchronized void close() {
         schemaIdPool.close();
         for (PartitionIDPool pool : idPools.values()) {

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/internal/AbstractElement.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/internal/AbstractElement.java
@@ -98,6 +98,7 @@ public abstract class AbstractElement implements InternalElement, Comparable<Tit
         return id;
     }
 
+    @Override
     public boolean hasId() {
         return !isTemporaryId(longId());
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/log/StandardTransactionLogProcessor.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/log/StandardTransactionLogProcessor.java
@@ -125,6 +125,7 @@ public class StandardTransactionLogProcessor implements TransactionRecovery {
         return new long[]{successTxCounter.get(),failureTxCounter.get()};
     }
 
+    @Override
     public synchronized void shutdown() throws TitanException {
         cleaner.close(CLEAN_SLEEP_TIME);
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/QueryContainer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/QueryContainer.java
@@ -219,6 +219,7 @@ public class QueryContainer {
             return this;
         }
 
+        @Override
         public QueryBuilder type(RelationType type) {
             super.type(type);
             return this;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/computer/PartitionVertexAggregate.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/olap/computer/PartitionVertexAggregate.java
@@ -26,10 +26,12 @@ public class PartitionVertexAggregate<M> extends VertexState<M> {
         return (EntryList)properties;
     }
 
+    @Override
     public<V> void setProperty(String key, V value, Map<String,Integer> keyMap) {
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public<V> V getProperty(String key, Map<String,Integer> keyMap) {
         throw new UnsupportedOperationException();
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanPredicate.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/TitanPredicate.java
@@ -50,6 +50,7 @@ public interface TitanPredicate extends BiPredicate<Object, Object> {
      * Returns the negation of this predicate if it exists, otherwise an exception is thrown. Check {@link #hasNegation()} first.
      * @return
      */
+    @Override
     public TitanPredicate negate();
 
     /**

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/condition/MultiCondition.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/condition/MultiCondition.java
@@ -39,15 +39,18 @@ public abstract class MultiCondition<E extends TitanElement> extends ArrayList<C
         super.addAll(cond);
     }
 
+    @Override
     public boolean add(Condition<E> condition) {
         assert condition != null;
         return super.add(condition);
     }
 
+    @Override
     public int size() {
         return super.size();
     }
 
+    @Override
     public Condition<E> get(int position) {
         return super.get(position);
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/JointIndexQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/graph/JointIndexQuery.java
@@ -103,6 +103,7 @@ public class JointIndexQuery extends BaseQuery implements BackendQuery<JointInde
             this.query = query;
         }
 
+        @Override
         public void observeWith(QueryProfiler prof) {
             this.profiler = prof.addNested(QueryProfiler.AND_QUERY);
             profiler.setAnnotation(QueryProfiler.QUERY_ANNOTATION,query);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsGraph.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsGraph.java
@@ -44,6 +44,7 @@ public abstract class TitanBlueprintsGraph implements TitanGraph {
 
     private ThreadLocal<TitanBlueprintsTransaction> txs = new ThreadLocal<TitanBlueprintsTransaction>() {
 
+        @Override
         protected TitanBlueprintsTransaction initialValue() {
             return null;
         }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
@@ -425,6 +425,7 @@ public class StandardTitanTx extends TitanBlueprintsTransaction implements TypeI
         return vertexCache.get(vertexid, existingVertexRetriever);
     }
 
+    @Override
     public InternalVertex getInternalVertex(long vertexid) {
         //return vertex but potentially check for existence
         return vertexCache.get(vertexid, internalVertexRetriever);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTransactionBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTransactionBuilder.java
@@ -280,6 +280,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
         return verifyUniqueness;
     }
 
+    @Override
     public boolean hasPropertyPrefetching() {
         return propertyPrefetching;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/CompositeIndexType.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/CompositeIndexType.java
@@ -11,6 +11,7 @@ public interface CompositeIndexType extends IndexType {
 
     public long getID();
 
+    @Override
     public IndexField[] getFieldKeys();
 
     public SchemaStatus getStatus();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/MixedIndexType.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/MixedIndexType.java
@@ -7,8 +7,10 @@ import com.thinkaurelius.titan.core.PropertyKey;
  */
 public interface MixedIndexType extends IndexType {
 
+    @Override
     public ParameterIndexField[] getFieldKeys();
 
+    @Override
     public ParameterIndexField getField(PropertyKey key);
 
     public String getStoreName();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardRelationTypeMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardRelationTypeMaker.java
@@ -51,6 +51,7 @@ public abstract class StandardRelationTypeMaker implements RelationTypeMaker {
     }
 
 
+    @Override
     public String getName() {
         return this.name;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardVertexLabelMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardVertexLabelMaker.java
@@ -36,6 +36,7 @@ public class StandardVertexLabelMaker implements VertexLabelMaker {
     }
 
 
+    @Override
     public String getName() {
         return name;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/indextype/CompositeIndexTypeWrapper.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/indextype/CompositeIndexTypeWrapper.java
@@ -76,6 +76,7 @@ public class CompositeIndexTypeWrapper extends IndexTypeWrapper implements Compo
 
     private ConsistencyModifier consistency = null;
 
+    @Override
     public ConsistencyModifier getConsistencyModifier() {
         if (consistency==null) {
             consistency = TypeUtil.getConsistencyModifier(base);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/system/EmptyRelationType.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/system/EmptyRelationType.java
@@ -53,6 +53,7 @@ public abstract class EmptyRelationType extends EmptyVertex implements InternalR
         return Collections.EMPTY_LIST;
     }
 
+    @Override
     public Integer getTTL() {
         return 0;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/vertices/RelationTypeVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/vertices/RelationTypeVertex.java
@@ -53,6 +53,7 @@ public abstract class RelationTypeVertex extends TitanSchemaVertex implements In
 
     private ConsistencyModifier consistency = null;
 
+    @Override
     public ConsistencyModifier getConsistencyModifier() {
         if (consistency==null) {
             consistency = TypeUtil.getConsistencyModifier(this);
@@ -70,6 +71,7 @@ public abstract class RelationTypeVertex extends TitanSchemaVertex implements In
         return ttl;
     }
 
+    @Override
     public InternalRelationType getBaseType() {
         Entry entry = Iterables.getOnlyElement(getRelated(TypeDefinitionCategory.RELATIONTYPE_INDEX,Direction.IN),null);
         if (entry==null) return null;
@@ -77,6 +79,7 @@ public abstract class RelationTypeVertex extends TitanSchemaVertex implements In
         return (InternalRelationType)entry.getSchemaType();
     }
 
+    @Override
     public Iterable<InternalRelationType> getRelationIndexes() {
         return Iterables.concat(ImmutableList.of(this),Iterables.transform(getRelated(TypeDefinitionCategory.RELATIONTYPE_INDEX,Direction.OUT),new Function<Entry, InternalRelationType>() {
             @Nullable
@@ -90,6 +93,7 @@ public abstract class RelationTypeVertex extends TitanSchemaVertex implements In
 
     private List<IndexType> indexes = null;
 
+    @Override
     public Iterable<IndexType> getKeyIndexes() {
         List<IndexType> result = indexes;
         if (result==null) {
@@ -105,6 +109,7 @@ public abstract class RelationTypeVertex extends TitanSchemaVertex implements In
         return result;
     }
 
+    @Override
     public void resetCache() {
         super.resetCache();
         indexes=null;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/vertices/TitanSchemaVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/vertices/TitanSchemaVertex.java
@@ -124,6 +124,7 @@ public class TitanSchemaVertex extends CacheVertex implements SchemaSource {
      * Resets the internal caches used to speed up lookups on this index type.
      * This is needed when the type gets modified in the {@link com.thinkaurelius.titan.graphdb.database.management.ManagementSystem}.
      */
+    @Override
     public void resetCache() {
         name = null;
         definition=null;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
@@ -131,6 +131,7 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
 	 * ---------------------------------------------------------------
 	 */
 
+    @Override
     public<V> TitanVertexProperty<V> property(final String key, final V value, final Object... keyValues) {
         TitanVertexProperty<V> p = tx().addProperty(it(), tx().getOrCreatePropertyKey(key), value);
         ElementHelper.attachProperties(p,keyValues);
@@ -152,14 +153,17 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
         return edge;
     }
 
+    @Override
     public Iterator<Edge> edges(Direction direction, String... labels) {
         return (Iterator)query().direction(direction).labels(labels).edges().iterator();
     }
 
+    @Override
     public <V> Iterator<VertexProperty<V>> properties(String... keys) {
         return (Iterator)query().direction(Direction.OUT).keys(keys).properties().iterator();
     }
 
+    @Override
     public Iterator<Vertex> vertices(final Direction direction, final String... edgeLabels) {
         return (Iterator)query().direction(direction).labels(edgeLabels).vertices().iterator();
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/PreloadedVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/PreloadedVertex.java
@@ -101,6 +101,7 @@ public class PreloadedVertex extends CacheVertex {
         return p;
     }
 
+    @Override
     public <V> TitanVertexProperty<V> property(final String key, final V value, final Object... keyValues) {
         return property(VertexProperty.Cardinality.single, key, value, keyValues);
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/IntHashSet.java
@@ -23,10 +23,12 @@ public class IntHashSet extends IntIntHashMap implements IntSet {
         super(size);
     }
 
+    @Override
     public boolean add(int value) {
         return super.put(value, defaultValue)==0;
     }
 
+    @Override
     public boolean addAll(int[] values) {
         boolean addedAll = true;
         for (int i = 0; i < values.length; i++) {
@@ -35,10 +37,12 @@ public class IntHashSet extends IntIntHashMap implements IntSet {
         return addedAll;
     }
 
+    @Override
     public boolean contains(int value) {
         return super.containsKey(value);
     }
 
+    @Override
     public int[] getAll() {
         KeysContainer keys = keys();
         int[] all = new int[keys.size()];

--- a/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
+++ b/titan-es/src/main/java/com/thinkaurelius/titan/diskstorage/es/ElasticSearchIndex.java
@@ -694,6 +694,7 @@ public class ElasticSearchIndex implements IndexProvider {
     }
 
 
+    @Override
     public void restore(Map<String,Map<String, List<IndexEntry>>> documents, KeyInformation.IndexRetriever informations, BaseTransaction tx) throws BackendException {
         BulkRequestBuilder bulk = client.prepareBulk();
         int requests = 0;

--- a/titan-hadoop-parent/titan-hadoop-core/src/main/java/com/thinkaurelius/titan/hadoop/formats/util/TitanVertexDeserializer.java
+++ b/titan-hadoop-parent/titan-hadoop-core/src/main/java/com/thinkaurelius/titan/hadoop/formats/util/TitanVertexDeserializer.java
@@ -224,6 +224,7 @@ public class TitanVertexDeserializer implements AutoCloseable {
         }
     }
 
+    @Override
     public void close() {
         setup.close();
     }

--- a/titan-hadoop-parent/titan-hadoop-core/src/main/java/com/thinkaurelius/titan/hadoop/scan/CassandraHadoopScanRunner.java
+++ b/titan-hadoop-parent/titan-hadoop-core/src/main/java/com/thinkaurelius/titan/hadoop/scan/CassandraHadoopScanRunner.java
@@ -29,6 +29,7 @@ public class CassandraHadoopScanRunner extends AbstractHadoopScanRunner<Cassandr
         super(vertexScanJob);
     }
 
+    @Override
     protected CassandraHadoopScanRunner self() {
         return this;
     }

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/HBaseStorageSetup.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/HBaseStorageSetup.java
@@ -194,6 +194,7 @@ public class HBaseStorageSetup {
      */
     private static void registerKillerHook(final HBaseStatus stat) {
         Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
             public void run() {
                 shutdownHBase(stat);
             }

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseIDAuthorityTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseIDAuthorityTest.java
@@ -32,6 +32,7 @@ public class HBaseIDAuthorityTest extends IDAuthorityTest {
             HBaseStorageSetup.killIfRunning();
     }
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         return new HBaseStoreManager(HBaseStorageSetup.getHBaseConfiguration());
     }

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseLockStoreTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseLockStoreTest.java
@@ -24,6 +24,7 @@ public class HBaseLockStoreTest extends LockKeyColumnValueStoreTest {
             HBaseStorageSetup.killIfRunning();
     }
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager(int idx) throws BackendException {
         return new HBaseStoreManager(HBaseStorageSetup.getHBaseConfiguration());
     }

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseMultiWriteStoreTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseMultiWriteStoreTest.java
@@ -25,6 +25,7 @@ public class HBaseMultiWriteStoreTest extends MultiWriteKeyColumnValueStoreTest 
             HBaseStorageSetup.killIfRunning();
     }
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         return new HBaseStoreManager(HBaseStorageSetup.getHBaseConfiguration());
     }

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreTest.java
@@ -29,11 +29,13 @@ public class HBaseStoreTest extends KeyColumnValueStoreTest {
             HBaseStorageSetup.killIfRunning();
     }
 
+    @Override
     public KeyColumnValueStoreManager openStorageManager() throws BackendException {
         WriteConfiguration config = HBaseStorageSetup.getHBaseGraphConfiguration();
         return new HBaseStoreManager(new BasicConfiguration(GraphDatabaseConfiguration.ROOT_NS,config, BasicConfiguration.Restriction.NONE));
     }
 
+    @Override
     @Test
     public void testGetKeysWithKeyRange() throws Exception {
         super.testGetKeysWithKeyRange();

--- a/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrTitanIndexTest.java
+++ b/titan-solr/src/test/java/com/thinkaurelius/titan/diskstorage/solr/SolrTitanIndexTest.java
@@ -35,6 +35,7 @@ public abstract class SolrTitanIndexTest extends TitanIndexTest {
         return false;
     }
 
+    @Override
     @Test
     public void testRawQueries() {
         clopen(option(SolrIndex.DYNAMIC_FIELDS,TitanIndexTest.INDEX),false);

--- a/titan-test/src/main/java/com/thinkaurelius/titan/DaemonRunner.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/DaemonRunner.java
@@ -77,6 +77,7 @@ public abstract class DaemonRunner<S> {
             return;
         }
         killerHook = new Thread() {
+            @Override
             public void run() {
                 killAndUnregisterHook(stat);
             }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/TestBed.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/TestBed.java
@@ -140,6 +140,7 @@ public class TestBed {
             other.observe(combined);
         }
 
+        @Override
         public boolean observes() {
             return observed;
         }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/SimpleScanJob.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/SimpleScanJob.java
@@ -100,6 +100,7 @@ public class SimpleScanJob implements ScanJob {
         }
     }
 
+    @Override
     public void workerIterationEnd(ScanMetrics metrics) {
         metrics.incrementCustom(TEARDOWN_COUNT);
     }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -2479,6 +2479,7 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
         final AtomicInteger txSuccess = new AtomicInteger(0);
         for (int i = 0; i < number; i++) {
             new Thread() {
+                @Override
                 public void run() {
                     awaitAllThreadsReady();
                     TitanTransaction tx = graph.newTransaction();

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanPartitionGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanPartitionGraphTest.java
@@ -69,6 +69,7 @@ public abstract class TitanPartitionGraphTest extends TitanGraphBaseTest {
 
     private IDManager idManager;
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/titan-test/src/main/java/com/thinkaurelius/titan/olap/OLAPTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/olap/OLAPTest.java
@@ -41,6 +41,7 @@ public abstract class OLAPTest extends TitanGraphBaseTest {
     private static final Logger log =
             LoggerFactory.getLogger(OLAPTest.class);
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/titan-test/src/main/java/com/thinkaurelius/titan/testutil/CsvConsumer.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/testutil/CsvConsumer.java
@@ -126,6 +126,7 @@ public class CsvConsumer implements IResultsConsumer {
         printHeader();
     }
 
+    @Override
     public synchronized void accept(Result r) throws IOException {
         Joiner j = Joiner.on(separator);
         List<String> fields = new ArrayList<String>(Column.values().length);

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryGraphTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryGraphTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public class InMemoryGraphTest extends TitanGraphTest {
 
+    @Override
     public WriteConfiguration getConfiguration() {
         ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
         config.set(GraphDatabaseConfiguration.STORAGE_BACKEND,"inmemory");
@@ -40,18 +41,23 @@ public class InMemoryGraphTest extends TitanGraphTest {
         newTx();
     }
 
+    @Override
     @Test
     public void testLocalGraphConfiguration() {}
 
+    @Override
     @Test
     public void testMaskableGraphConfig() {}
 
+    @Override
     @Test
     public void testGlobalGraphConfig() {}
 
+    @Override
     @Test
     public void testGlobalOfflineGraphConfig() {}
 
+    @Override
     @Test
     public void testFixedGraphConfig() {}
 

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryOLAPTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryOLAPTest.java
@@ -12,6 +12,7 @@ import com.thinkaurelius.titan.olap.OLAPTest;
 
 public class InMemoryOLAPTest extends OLAPTest {
 
+    @Override
     public WriteConfiguration getConfiguration() {
         ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
         config.set(GraphDatabaseConfiguration.STORAGE_BACKEND,"inmemory");

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryTitanIoTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryTitanIoTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class InMemoryTitanIoTest extends TitanIoTest {
+    @Override
     public WriteConfiguration getConfiguration() {
         ModifiableConfiguration config = GraphDatabaseConfiguration.buildGraphConfiguration();
         config.set(GraphDatabaseConfiguration.STORAGE_BACKEND,"inmemory");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1161

Please let me know if you have any questions.

Kirill Vlasov
