### PR TITLE
Constructors should only call non-overridable methods

### DIFF
--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CLevel.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CLevel.java
@@ -27,6 +27,8 @@ public enum CLevel implements CLevelInterface { // One ring to rule them all
         astyanax = com.netflix.astyanax.model.ConsistencyLevel.valueOf("CL_" + toString());
     }
 
+
+
     @Override
     public org.apache.cassandra.db.ConsistencyLevel getDB() {
         return db;
@@ -55,5 +57,10 @@ public enum CLevel implements CLevelInterface { // One ring to rule them all
             }
         }
         throw new IllegalArgumentException("Unrecognized cassandra consistency level: " + value);
+    }
+
+    @Override
+    public final String toString() {
+        return super.toString();
     }
 }

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraTransaction.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CassandraTransaction.java
@@ -39,7 +39,7 @@ public class CassandraTransaction extends AbstractStoreTransaction {
         return (CassandraTransaction) txh;
     }
 
-    public String toString() {
+    public final String toString() {
         StringBuilder sb = new StringBuilder(64);
         sb.append("CassandraTransaction@");
         sb.append(Integer.toHexString(hashCode()));

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/thrift/CassandraThriftStoreManager.java
@@ -199,7 +199,7 @@ public class CassandraThriftStoreManager extends AbstractCassandraStoreManager {
 
     @Override
     @SuppressWarnings("unchecked")
-    public IPartitioner getCassandraPartitioner() throws BackendException {
+    public final IPartitioner getCassandraPartitioner() throws BackendException {
         CTConnection conn = null;
         try {
             conn = pool.borrowObject(SYSTEM_KS);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/Backend.java
@@ -380,12 +380,12 @@ public class Backend implements LockerProvider, AutoCloseable {
         return configuration.get(METRICS_MERGE_STORES) ? METRICS_MERGED_CACHE : storeName + METRICS_CACHE_SUFFIX;
     }
 
-    public KCVSLogManager getKCVSLogManager(String logName) {
+    public final KCVSLogManager getKCVSLogManager(String logName) {
         Preconditions.checkArgument(configuration.restrictTo(logName).get(LOG_BACKEND).equalsIgnoreCase(LOG_BACKEND.getDefaultValue()));
         return (KCVSLogManager)getLogManager(logName);
     }
 
-    public LogManager getLogManager(String logName) {
+    public final LogManager getLogManager(String logName) {
         return getLogManager(configuration, logName, storeManager);
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/common/AbstractStoreTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/common/AbstractStoreTransaction.java
@@ -29,7 +29,7 @@ public abstract class AbstractStoreTransaction implements StoreTransaction {
     }
 
     @Override
-    public BaseTransactionConfig getConfiguration() {
+    public final BaseTransactionConfig getConfiguration() {
         return config;
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexEntry.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/indexing/IndexEntry.java
@@ -44,7 +44,7 @@ public class IndexEntry implements MetaAnnotated, MetaAnnotatable {
     private Map<EntryMetaData,Object> metadata = EntryMetaData.EMPTY_METADATA;
 
     @Override
-    public synchronized Object setMetaData(EntryMetaData key, Object value) {
+    public final synchronized Object setMetaData(EntryMetaData key, Object value) {
         if (metadata == EntryMetaData.EMPTY_METADATA)
             metadata = new EntryMetaData.Map();
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/KeyRangeQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/KeyRangeQuery.java
@@ -50,7 +50,7 @@ public class KeyRangeQuery extends SliceQuery {
     }
 
     @Override
-    public KeyRangeQuery setLimit(int limit) {
+    public final KeyRangeQuery setLimit(int limit) {
         super.setLimit(limit);
         return this;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/KeySliceQuery.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/KeySliceQuery.java
@@ -34,7 +34,7 @@ public class KeySliceQuery extends SliceQuery {
     }
 
     @Override
-    public KeySliceQuery setLimit(int limit) {
+    public final KeySliceQuery setLimit(int limit) {
         super.setLimit(limit);
         return this;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StandardStoreFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StandardStoreFeatures.java
@@ -191,106 +191,106 @@ public class StandardStoreFeatures implements StoreFeatures {
             supportsInterruption(template.supportsInterruption());
         }
 
-        public Builder unorderedScan(boolean b) {
+        public final Builder unorderedScan(boolean b) {
             unorderedScan = b;
             return this;
         }
 
-        public Builder orderedScan(boolean b) {
+        public final Builder orderedScan(boolean b) {
             orderedScan = b;
             return this;
         }
 
-        public Builder multiQuery(boolean b) {
+        public final  Builder multiQuery(boolean b) {
             multiQuery = b;
             return this;
         }
 
-        public Builder locking(boolean b) {
+        public final Builder locking(boolean b) {
             locking = b;
             return this;
         }
 
-        public Builder batchMutation(boolean b) {
+        public final Builder batchMutation(boolean b) {
             batchMutation = b;
             return this;
         }
 
-        public Builder localKeyPartition(boolean b) {
+        public final Builder localKeyPartition(boolean b) {
             localKeyPartition = b;
             return this;
         }
 
-        public Builder keyOrdered(boolean b) {
+        public final Builder keyOrdered(boolean b) {
             keyOrdered = b;
             return this;
         }
 
-        public Builder distributed(boolean b) {
+        public final Builder distributed(boolean b) {
             distributed = b;
             return this;
         }
 
-        public Builder transactional(boolean b) {
+        public final Builder transactional(boolean b) {
             transactional = b;
             return this;
         }
 
-        public Builder timestamps(boolean b) {
+        public final Builder timestamps(boolean b) {
             timestamps = b;
             return this;
         }
 
-        public Builder preferredTimestamps(TimestampProviders t) {
+        public final Builder preferredTimestamps(TimestampProviders t) {
             preferredTimestamps = t;
             return this;
         }
 
-        public Builder cellTTL(boolean b) {
+        public final Builder cellTTL(boolean b) {
             cellLevelTTL = b;
             return this;
         }
 
-        public Builder storeTTL(boolean b) {
+        public final Builder storeTTL(boolean b) {
             storeLevelTTL = b;
             return this;
         }
 
 
-        public Builder visibility(boolean b) {
+        public final Builder visibility(boolean b) {
             visibility = b;
             return this;
         }
 
-        public Builder persists(boolean b) {
+        public final Builder persists(boolean b) {
             supportsPersist = b;
             return this;
         }
 
-        public Builder keyConsistent(Configuration c) {
+        public final Builder keyConsistent(Configuration c) {
             keyConsistent = true;
             keyConsistentTxConfig = c;
             return this;
         }
 
-        public Builder keyConsistent(Configuration global, Configuration local) {
+        public final Builder keyConsistent(Configuration global, Configuration local) {
             keyConsistent = true;
             keyConsistentTxConfig = global;
             localKeyConsistentTxConfig = local;
             return this;
         }
 
-        public Builder notKeyConsistent() {
+        public final Builder notKeyConsistent() {
             keyConsistent = false;
             return this;
         }
 
-        public Builder scanTxConfig(Configuration c) {
+        public final Builder scanTxConfig(Configuration c) {
             scanTxConfig = c;
             return this;
         }
 
-        public Builder supportsInterruption(boolean i)
+        public final Builder supportsInterruption(boolean i)
         {
             supportsInterruption = i;
             return this;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StandardBaseTransactionConfig.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StandardBaseTransactionConfig.java
@@ -101,7 +101,7 @@ public class StandardBaseTransactionConfig implements BaseTransactionConfig {
             timestampProvider(template.getTimestampProvider());
         }
 
-        public Builder groupName(String group) {
+        public final Builder groupName(String group) {
             groupName = group;
             return this;
         }
@@ -111,12 +111,12 @@ public class StandardBaseTransactionConfig implements BaseTransactionConfig {
             return this;
         }
 
-        public Builder timestampProvider(TimestampProvider times) {
+        public final Builder timestampProvider(TimestampProvider times) {
             this.times = times;
             return this;
         }
 
-        public Builder customOptions(Configuration c) {
+        public final Builder customOptions(Configuration c) {
             customOptions = c;
             Preconditions.checkNotNull(customOptions, "Null custom options disallowed; use an empty Configuration object instead");
             return this;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayBuffer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/util/StaticArrayBuffer.java
@@ -84,7 +84,7 @@ public class StaticArrayBuffer implements StaticBuffer {
     }
 
     @Override
-    public int length() {
+    public final int length() {
         return limit - offset;
     }
 

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/placement/PropertyPlacementStrategy.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/placement/PropertyPlacementStrategy.java
@@ -45,7 +45,7 @@ public class PropertyPlacementStrategy extends SimpleBulkPlacementStrategy {
         setPartitionKey(key);
     }
 
-    public void setPartitionKey(String key) {
+    public final void setPartitionKey(String key) {
         Preconditions.checkArgument(StringUtils.isNotBlank(key),"Invalid key configured: %s",key);
         this.key=key;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/placement/SimplePartitionAssignment.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/idassigner/placement/SimplePartitionAssignment.java
@@ -18,7 +18,7 @@ public class SimplePartitionAssignment implements PartitionAssignment {
         setPartitionID(id);
     }
 
-    public void setPartitionID(int id) {
+    public final void setPartitionID(int id) {
         Preconditions.checkArgument(id >= 0);
         this.partitionID = id;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/StandardSerializer.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/database/serialize/StandardSerializer.java
@@ -129,7 +129,7 @@ public class StandardSerializer implements AttributeHandler, Serializer {
         registerClassInternal(CLASS_REGISTRATION_OFFSET + registrationNo, datatype, serializer);
     }
 
-    public synchronized <V> void registerClassInternal(int registrationNo, Class<? extends V> datatype, AttributeSerializer<V> serializer) {
+    public final synchronized <V> void registerClassInternal(int registrationNo, Class<? extends V> datatype, AttributeSerializer<V> serializer) {
         Preconditions.checkArgument(registrationNo>0); //must be bigger than 0 since 0 is used to indicate null values
         Preconditions.checkNotNull(datatype);
         Preconditions.checkArgument(!handlers.containsKey(datatype), "DataType has already been registered: %s", datatype);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/ResultMergeSortIterator.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/query/ResultMergeSortIterator.java
@@ -51,7 +51,7 @@ public class ResultMergeSortIterator<R> implements Iterator<R> {
         return current;
     }
 
-    public R nextInternal() {
+    public final R nextInternal() {
         if (nextFirst == null && first.hasNext()) {
             nextFirst = first.next();
             assert nextFirst != null;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanIoRegistry.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanIoRegistry.java
@@ -4,6 +4,7 @@ import com.thinkaurelius.titan.core.attribute.Geoshape;
 import com.thinkaurelius.titan.graphdb.relations.RelationIdentifier;
 import com.thinkaurelius.titan.graphdb.tinkerpop.io.graphson.TitanGraphSONModule;
 import org.apache.tinkerpop.gremlin.structure.io.AbstractIoRegistry;
+import org.apache.tinkerpop.gremlin.structure.io.Io;
 import org.apache.tinkerpop.gremlin.structure.io.graphson.GraphSONIo;
 import org.apache.tinkerpop.gremlin.structure.io.gryo.GryoIo;
 
@@ -21,5 +22,10 @@ public class TitanIoRegistry extends AbstractIoRegistry {
         register(GraphSONIo.class, null, TitanGraphSONModule.getInstance());
         register(GryoIo.class, RelationIdentifier.class, null);
         register(GryoIo.class, Geoshape.class, new Geoshape.GeoShapeGryoSerializer());
+    }
+
+    @Override
+    protected final void register(Class<? extends Io> ioClass, Class clazz, Object serializer) {
+        super.register(ioClass, clazz, serializer);
     }
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/io/graphson/TitanGraphSONModule.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/io/graphson/TitanGraphSONModule.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
@@ -28,6 +30,16 @@ public class TitanGraphSONModule extends SimpleModule {
 
         addDeserializer(RelationIdentifier.class, new RelationIdentifierDeserializer());
         addDeserializer(Geoshape.class, new Geoshape.GeoshapeGsonDeserializer());
+    }
+
+    @Override
+    public final <T> SimpleModule addSerializer(Class<? extends T> aClass, JsonSerializer<T> jsonSerializer) {
+        return super.addSerializer(aClass, jsonSerializer);
+    }
+
+    @Override
+    public final <T> SimpleModule addDeserializer(Class<T> aClass, JsonDeserializer<? extends T> jsonDeserializer) {
+        return super.addDeserializer(aClass, jsonDeserializer);
     }
 
     private static final TitanGraphSONModule INSTANCE = new TitanGraphSONModule();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTransactionBuilder.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTransactionBuilder.java
@@ -117,13 +117,13 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
-    public StandardTransactionBuilder readOnly() {
+    public final StandardTransactionBuilder readOnly() {
         this.isReadOnly = true;
         return this;
     }
 
     @Override
-    public StandardTransactionBuilder enableBatchLoading() {
+    public final StandardTransactionBuilder enableBatchLoading() {
         hasEnabledBatchLoading = true;
         checkExternalVertexExistence(false);
         consistencyChecks(false);
@@ -139,7 +139,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
-    public StandardTransactionBuilder vertexCacheSize(int size) {
+    public final StandardTransactionBuilder vertexCacheSize(int size) {
         Preconditions.checkArgument(size >= 0);
         this.vertexCacheSize = size;
         this.indexCacheWeight = size / 2;
@@ -147,7 +147,7 @@ public class StandardTransactionBuilder implements TransactionConfiguration, Tra
     }
 
     @Override
-    public TransactionBuilder dirtyVertexSize(int size) {
+    public final TransactionBuilder dirtyVertexSize(int size) {
         this.dirtyVertexSize = size;
         return this;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardPropertyKeyMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardPropertyKeyMaker.java
@@ -43,7 +43,7 @@ public class StandardPropertyKeyMaker extends StandardRelationTypeMaker implemen
     }
 
     @Override
-    public StandardPropertyKeyMaker cardinality(Cardinality cardinality) {
+    public final StandardPropertyKeyMaker cardinality(Cardinality cardinality) {
         super.multiplicity(Multiplicity.convert(cardinality));
         return this;
     }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardRelationTypeMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/StandardRelationTypeMaker.java
@@ -170,7 +170,7 @@ public abstract class StandardRelationTypeMaker implements RelationTypeMaker {
         return this;
     }
 
-    public StandardRelationTypeMaker name(String name) {
+    public final StandardRelationTypeMaker name(String name) {
         SystemTypeManager.isNotSystemName(getSchemaCategory(), name);
         this.name = name;
         return this;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeDefinitionMap.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/types/TypeDefinitionMap.java
@@ -22,7 +22,7 @@ public class TypeDefinitionMap extends EnumMap<TypeDefinitionCategory,Object> {
         }
     }
 
-    public TypeDefinitionMap setValue(TypeDefinitionCategory type, Object value) {
+    public final TypeDefinitionMap setValue(TypeDefinitionCategory type, Object value) {
         assert type  != null;
         assert value != null;
         assert type.verifyAttribute(value);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/CompactMap.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/CompactMap.java
@@ -324,7 +324,7 @@ public class CompactMap implements Map<String,Object> {
 
         KeyContainer() {}
 
-        void setKeys(final String[] keys) {
+        final void setKeys(final String[] keys) {
             checkKeys(keys);
             this.keys = keys;
             this.hashcode= Arrays.hashCode(keys);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/RangeInterval.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/util/datastructures/RangeInterval.java
@@ -29,14 +29,14 @@ public class RangeInterval<T> implements Interval<T> {
         setEnd(end,true);
     }
 
-    public RangeInterval<T> setStart(T start, boolean inclusive) {
+    public final RangeInterval<T> setStart(T start, boolean inclusive) {
         Preconditions.checkArgument(start instanceof Comparable);
         this.start=start;
         setStartInclusive(inclusive);
         return this;
     }
 
-    public RangeInterval<T> setEnd(T end, boolean inclusive) {
+    public final RangeInterval<T> setEnd(T end, boolean inclusive) {
         Preconditions.checkArgument(end instanceof Comparable);
         this.end=end;
         setEndInclusive(inclusive);

--- a/titan-hbase-parent/titan-hbase-core/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
+++ b/titan-hbase-parent/titan-hbase-core/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
@@ -357,7 +357,7 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
         return "hbase[" + tableName + "@" + super.toString() + "]";
     }
 
-    public void dumpOpenManagers() {
+    public final void dumpOpenManagers() {
         int estimatedSize = openManagers.size();
         logger.trace("---- Begin open HBase store manager list ({} managers) ----", estimatedSize);
         for (HBaseStoreManager m : openManagers.keySet()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of sonar issue squid:S1699 - Constructors should only call non-overridable methods
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1699
Please let me know if you have any questions.
Kirill Vlasov
