### PR TITLE
Using cnx.getAdmin() instead of new HBaseAdmin in titan-hbase-10.

### DIFF
--- a/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseAdmin1_0.java
+++ b/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseAdmin1_0.java
@@ -5,19 +5,12 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.thinkaurelius.titan.util.system.IOUtils;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotDisabledException;
 import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
 
 public class HBaseAdmin1_0 implements AdminMask
 {
@@ -26,7 +19,7 @@ public class HBaseAdmin1_0 implements AdminMask
 
     private final Admin adm;
 
-    public HBaseAdmin1_0(HBaseAdmin adm)
+    public HBaseAdmin1_0(Admin adm)
     {
         this.adm = adm;
     }

--- a/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseCompat1_0.java
+++ b/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseCompat1_0.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.HConnectionManager;
 import org.apache.hadoop.hbase.io.compress.Compression;
 
 public class HBaseCompat1_0 implements HBaseCompat {

--- a/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HConnection1_0.java
+++ b/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HConnection1_0.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
 
 public class HConnection1_0 implements ConnectionMask
 {
@@ -25,7 +24,7 @@ public class HConnection1_0 implements ConnectionMask
     @Override
     public AdminMask getAdmin() throws IOException
     {
-        return new HBaseAdmin1_0(new HBaseAdmin(cnx));
+        return new HBaseAdmin1_0(cnx.getAdmin());
     }
 
     @Override

--- a/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HTable1_0.java
+++ b/titan-hbase-parent/titan-hbase-10/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HTable1_0.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Row;


### PR DESCRIPTION
This is a minor cleanup issue for hbase 1.0 and helps make titan be compatible with cloud bigtable as well.
