### PR TITLE
Added LOCAL_ONE Cassandra consistency level option.

### DIFF
--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CLevel.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/CLevel.java
@@ -14,6 +14,7 @@ public enum CLevel implements CLevelInterface { // One ring to rule them all
     THREE,
     QUORUM,
     ALL,
+    LOCAL_ONE,
     LOCAL_QUORUM,
     EACH_QUORUM;
 


### PR DESCRIPTION
Small update to bring Titan's consistency levels in line with what Cassandra makes available.  I did not add SERIAL and LOCAL_SERIAL because those do not appear to be available via Thrift.
