### PR TITLE
Fix wrong cassandra inputformat configuration

### DIFF
--- a/titan-dist/src/assembly/static/conf/hadoop-graph/read-cassandra.properties
+++ b/titan-dist/src/assembly/static/conf/hadoop-graph/read-cassandra.properties
@@ -15,7 +15,7 @@ gremlin.hadoop.outputLocation=output
 titanmr.ioformat.conf.storage.backend=cassandra
 titanmr.ioformat.conf.storage.hostname=localhost
 titanmr.ioformat.conf.storage.port=9160
-titanmr.ioformat.conf.storage.keyspace=titan
+titanmr.ioformat.conf.storage.cassandra.keyspace=titan
 
 #
 # Apache Cassandra InputFormat configuration


### PR DESCRIPTION
When testing hadoop on titan 1.0.0 I had a problem with that it tried to use the keyspace 'titan', I couldn't at first figure out why because I used a copy of this file, but when I took a closer gander at this file I found that the '.cassandra' part was missing on the keyspace line.
