### PR TITLE
Add signatures for value-based type defaults

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/DefaultSchemaMaker.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/DefaultSchemaMaker.java
@@ -47,6 +47,10 @@ public interface DefaultSchemaMaker {
         return factory.cardinality(defaultPropertyCardinality(factory.getName())).dataType(Object.class).make();
     }
 
+    public default PropertyKey makePropertyKey(PropertyKeyMaker factory, Object value) {
+        return makePropertyKey(factory);
+    }
+
     /**
      * Creates a new vertex label with the default settings against the provided {@link VertexLabelMaker}.
      *

--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/SchemaInspector.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/schema/SchemaInspector.java
@@ -53,6 +53,10 @@ public interface SchemaInspector {
      */
     public PropertyKey getOrCreatePropertyKey(String name);
 
+    public default PropertyKey getOrCreatePropertyKey(String name, Object value) {
+        return getOrCreatePropertyKey(name);
+    }
+
     /**
      * Returns the property key with the given name. If it does not exist, NULL is returned
      *

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/transaction/StandardTitanTx.java
@@ -928,6 +928,17 @@ public class StandardTitanTx extends TitanBlueprintsTransaction implements TypeI
     }
 
     @Override
+    public PropertyKey getOrCreatePropertyKey(String name, Object value) {
+        RelationType et = getRelationType(name);
+        if (et == null) {
+            return config.getAutoSchemaMaker().makePropertyKey(makePropertyKey(name), value);
+        } else if (et.isPropertyKey()) {
+            return (PropertyKey) et;
+        } else
+            throw new IllegalArgumentException("The type of given name is not a key: " + name);
+    }
+
+    @Override
     public EdgeLabel getEdgeLabel(String name) {
         RelationType el = getRelationType(name);
         Preconditions.checkArgument(el==null || el.isEdgeLabel(), "The relation type with name [%s] is not an edge label",name);

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/vertices/AbstractVertex.java
@@ -132,14 +132,14 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
 	 */
 
     public<V> TitanVertexProperty<V> property(final String key, final V value, final Object... keyValues) {
-        TitanVertexProperty<V> p = tx().addProperty(it(), tx().getOrCreatePropertyKey(key), value);
+        TitanVertexProperty<V> p = tx().addProperty(it(), tx().getOrCreatePropertyKey(key, value), value);
         ElementHelper.attachProperties(p,keyValues);
         return p;
     }
 
     @Override
     public <V> TitanVertexProperty<V> property(final VertexProperty.Cardinality cardinality, final String key, final V value, final Object... keyValues) {
-        TitanVertexProperty<V> p = tx().addProperty(cardinality, it(), tx().getOrCreatePropertyKey(key), value);
+        TitanVertexProperty<V> p = tx().addProperty(cardinality, it(), tx().getOrCreatePropertyKey(key, value), value);
         ElementHelper.attachProperties(p,keyValues);
         return p;
     }


### PR DESCRIPTION
The previous implementation only provided property key names to
DefaultSchemaMaker instances, which limits users' ability to customize
behavior. This changeset also passes the property key value down to the
DefaultSchemaMaker, allowing more fine-grained analysis and potentially
better decisions around default types.
