### PR TITLE
Assert that loaded key count is 2000 after commit

### DIFF
--- a/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/diskstorage/KeyValueStoreTest.java
@@ -196,8 +196,8 @@ public abstract class KeyValueStoreTest extends AbstractKCVSTest {
             String[] values = generateValues();
             loadValues(values);
             RecordIterator<KeyValueEntry> iterator0 = getAllData(tx);
-            Assert.assertEquals(numKeys, KeyValueStoreUtil.count(iterator0));
             clopen();
+            Assert.assertEquals(numKeys, KeyValueStoreUtil.count(iterator0));
             RecordIterator<KeyValueEntry> iterator1 = getAllData(tx);
             RecordIterator<KeyValueEntry> iterator2 = getAllData(tx);
 


### PR DESCRIPTION
This test makes the assumption that the underlying store has the ability to read uncommitted transactions.
http://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/Cursor.html
This may very well be the behavior of Berkeley JE transactions as they are created in titan-berkeleyje, but it is not part of the OrderedKeyValueStore interface/specification. Actually, it seems like the isolation/lock modes are configurable in titan-berkeleyje.
