### PR TITLE
fixed Windows scripts based on TinkerPop

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/core/Titan.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/core/Titan.java
@@ -2,6 +2,8 @@ package com.thinkaurelius.titan.core;
 
 import com.thinkaurelius.titan.graphdb.configuration.TitanConstants;
 
+import org.apache.tinkerpop.gremlin.util.Gremlin;
+
 
 /**
  * Contains constants for this Titan Graph Database.
@@ -17,5 +19,9 @@ public class Titan {
      */
     public static String version() {
         return TitanConstants.VERSION;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Titan " + Titan.version() + ", Apache TinkerPop " + Gremlin.version());
     }
 }

--- a/titan-dist/src/assembly/static/bin/gremlin-server.bat
+++ b/titan-dist/src/assembly/static/bin/gremlin-server.bat
@@ -1,13 +1,138 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License.
+
 :: Windows launcher script for Gremlin Server
-@echo off
 
-set work=%CD%
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+SET work=%CD%
 
-if [%work:~-3%]==[bin] cd ..
+IF [%work:~-3%]==[bin] CD ..
 
-set LIBDIR=lib
+IF NOT DEFINED TITAN_HOME (
+    SET TITAN_HOME=%CD%
+)
 
-set JAVA_OPTIONS=-Xms32m -Xmx512m -javaagent:%LIBDIR%/jamm-0.3.0.jar
+:: location of the Titan lib directory
+SET TITAN_LIB=%TITAN_HOME%\lib
+
+:: location of the Titan extensions directory
+IF NOT DEFINED TITAN_EXT (
+    SET TITAN_EXT=%TITAN_HOME%\ext
+)
+
+:: Set default message threshold for Log4j Gremlin's console appender
+IF NOT DEFINED GREMLIN_LOG_LEVEL (
+    SET GREMLIN_LOG_LEVEL=WARN
+)
+
+:: Hadoop winutils.exe needs to be available because hadoop-gremlin is installed and active by default
+IF NOT DEFINED HADOOP_HOME (
+    SET TITAN_WINUTILS=%TITAN_HOME%\bin\winutils.exe
+    IF EXIST !TITAN_WINUTILS! (
+        SET HADOOP_HOME=%TITAN_HOME%
+    ) ELSE (
+        ECHO HADOOP_HOME is not set.
+        ECHO Download http://public-repo-1.hortonworks.com/hdp-win-alpha/winutils.exe
+        ECHO Place it under !TITAN_WINUTILS!
+        PAUSE
+        GOTO :eof
+    )
+)
+
+:: set HADOOP_GREMLIN_LIBS by default to the Titan lib
+IF NOT DEFINED HADOOP_GREMLIN_LIBS (
+    SET HADOOP_GREMLIN_LIBS=%TITAN_LIB%
+)
+
+CD %TITAN_LIB%
+
+FOR /F "tokens=*" %%G IN ('dir /b "titan-*.jar"') DO SET TITAN_JARS=!TITAN_JARS!;%TITAN_LIB%\%%G
+
+FOR /F "tokens=*" %%G IN ('dir /b "jamm-*.jar"') DO SET JAMM_JAR=%TITAN_LIB%\%%G
+
+FOR /F "tokens=*" %%G IN ('dir /b "slf4j-log4j12-*.jar"') DO SET SLF4J_LOG4J_JAR=%TITAN_LIB%\%%G
+
+CD %TITAN_EXT%
+
+FOR /D /r %%i in (*) do (
+    SET EXTDIR_JARS=!EXTDIR_JARS!;%%i\*
+)
+
+CD %TITAN_HOME%
+
+:: put slf4j-log4j12 and Titan jars first because of conflict with logback
+SET CP=%CLASSPATH%;%SLF4J_LOG4J_JAR%;%TITAN_JARS%;%TITAN_LIB%\*;%EXTDIR_JARS%
+
+:: to debug plugin :install include -Divy.message.logger.level=4 -Dgroovy.grape.report.downloads=true
+:: to debug log4j include -Dlog4j.debug=true
+IF NOT DEFINED JAVA_OPTIONS (
+ SET JAVA_OPTIONS=-Xms32m -Xmx512m ^
+ -Dtitan.logdir=%TITAN_HOME%\log ^
+ -Dtinkerpop.ext=%TITAN_EXT% ^
+ -Dlogback.configurationFile=conf\logback.xml ^
+ -Dlog4j.configuration=file:/%TITAN_HOME%\conf\gremlin-server\log4j-server.properties ^
+ -Dlog4j.debug=true ^
+ -Dgremlin.log4j.level=%GREMLIN_LOG_LEVEL% ^
+ -javaagent:%JAMM_JAR%
+)
+
 
 :: Launch the application
-java -Dlog4j.configuration=../conf/log4j-server.properties %JAVA_OPTIONS% %JAVA_ARGS% -cp %LIBDIR%/*; org.apache.tinkerpop.gremlin.server.GremlinServer %*
+
+IF "%1" == "-i" ( 
+    GOTO install
+) else (
+    GOTO server
+)
+
+:: Start the Gremlin Server
+
+:server
+
+IF "%1" == "" (
+  SET GREMLIN_SERVER_YAML=%TITAN_HOME%\conf\gremlin-server\gremlin-server.yaml
+) ELSE (
+  SET GREMLIN_SERVER_YAML=%1
+)
+
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.server.GremlinServer %GREMLIN_SERVER_YAML%
+
+GOTO finally
+
+:: Install a plugin
+
+:install
+
+SET GRP_ART_VER=
+SHIFT
+
+:loop1
+IF "%1"=="" GOTO after_loop
+SET GRP_ART_VER=%GRP_ART_VER% %1
+SHIFT
+GOTO loop1
+
+:after_loop
+
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.server.util.GremlinServerInstall %GRP_ART_VER%
+
+GOTO finally
+
+:finally
+
+ENDLOCAL

--- a/titan-dist/src/assembly/static/bin/gremlin.bat
+++ b/titan-dist/src/assembly/static/bin/gremlin.bat
@@ -1,69 +1,140 @@
+:: Licensed to the Apache Software Foundation (ASF) under one
+:: or more contributor license agreements.  See the NOTICE file
+:: distributed with this work for additional information
+:: regarding copyright ownership.  The ASF licenses this file
+:: to you under the Apache License, Version 2.0 (the
+:: "License"); you may not use this file except in compliance
+:: with the License.  You may obtain a copy of the License at
+::
+::   http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing,
+:: software distributed under the License is distributed on an
+:: "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+:: KIND, either express or implied.  See the License for the
+:: specific language governing permissions and limitations
+:: under the License.
+
 :: Windows launcher script for Gremlin Console
 
-@echo off
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+SET work=%CD%
 
-::cd ..\lib
+IF [%work:~-3%]==[bin] CD ..
 
-::set LIBDIR=%CD%
+IF NOT DEFINED TITAN_HOME (
+    SET TITAN_HOME=%CD%
+)
 
-set LIBDIR=..\lib
+:: location of the Titan lib directory
+SET TITAN_LIB=%TITAN_HOME%\lib
 
-set OLD_CLASSPATH=%CLASSPATH%
-set CP=
+:: location of the Titan extensions directory
+IF NOT DEFINED TITAN_EXT (
+    SET TITAN_EXT=%TITAN_HOME%\ext
+)
 
-for %%i in (%LIBDIR%\*.jar) do call :concatsep %%i
+:: Set default message threshold for Log4j Gremlin's console appender
+IF NOT DEFINED GREMLIN_LOG_LEVEL (
+    SET GREMLIN_LOG_LEVEL=WARN
+)
 
-:: cd ..\..\..\
+:: Hadoop winutils.exe needs to be available because hadoop-gremlin is installed and active by default
+IF NOT DEFINED HADOOP_HOME (
+    SET TITAN_WINUTILS=%TITAN_HOME%\bin\winutils.exe
+    IF EXIST !TITAN_WINUTILS! (
+        SET HADOOP_HOME=%TITAN_HOME%
+    ) ELSE (
+        ECHO HADOOP_HOME is not set.
+        ECHO Download http://public-repo-1.hortonworks.com/hdp-win-alpha/winutils.exe
+        ECHO Place it under !TITAN_WINUTILS!
+        PAUSE
+        GOTO :eof
+    )
+)
 
-set JAVA_OPTIONS=-Xms32m -Xmx512m -javaagent:%LIBDIR%\jamm-0.3.0.jar
+:: set HADOOP_GREMLIN_LIBS by default to the Titan lib
+IF NOT DEFINED HADOOP_GREMLIN_LIBS (
+    SET HADOOP_GREMLIN_LIBS=%TITAN_LIB%
+)
+
+CD %TITAN_LIB%
+
+FOR /F "tokens=*" %%G IN ('dir /b "titan-*.jar"') DO SET TITAN_JARS=!TITAN_JARS!;%TITAN_LIB%\%%G
+
+FOR /F "tokens=*" %%G IN ('dir /b "jamm-*.jar"') DO SET JAMM_JAR=%TITAN_LIB%\%%G
+
+FOR /F "tokens=*" %%G IN ('dir /b "slf4j-log4j12-*.jar"') DO SET SLF4J_LOG4J_JAR=%TITAN_LIB%\%%G
+
+CD %TITAN_EXT%
+
+FOR /D /r %%i in (*) do (
+    SET EXTDIR_JARS=!EXTDIR_JARS!;%%i\*
+)
+
+CD %TITAN_HOME%
+
+:: put slf4j-log4j12 and Titan jars first because of conflict with logback
+SET CP=%CLASSPATH%;%SLF4J_LOG4J_JAR%;%TITAN_JARS%;%TITAN_LIB%\*;%EXTDIR_JARS%
+
+:: jline.terminal workaround for https://issues.apache.org/jira/browse/GROOVY-6453
+:: to debug plugin :install include -Divy.message.logger.level=4 -Dgroovy.grape.report.downloads=true
+:: to debug log4j include -Dlog4j.debug=true
+IF NOT DEFINED JAVA_OPTIONS (
+ SET JAVA_OPTIONS=-Xms32m -Xmx512m ^
+ -Dtinkerpop.ext=%TITAN_EXT% ^
+ -Dlogback.configurationFile=%TITAN_HOME%\conf\logback.xml ^
+ -Dlog4j.configuration=file:/%TITAN_HOME%\conf\log4j-console.properties ^
+ -Dgremlin.log4j.level=%GREMLIN_LOG_LEVEL% ^
+ -Djline.terminal=none ^
+ -javaagent:%JAMM_JAR%
+)
 
 :: Launch the application
 
-if "%1" == "" goto console
-if "%1" == "-e" goto script
-if "%1" == "-v" goto version
+IF "%1" == "" GOTO console
+IF "%1" == "-e" GOTO script
+IF "%1" == "-v" GOTO version
+
+:: Start the Gremlin Console
 
 :console
 
-set CLASSPATH=%CP%;%OLD_CLASSPATH%
-java %JAVA_OPTIONS% %JAVA_ARGS% org.apache.tinkerpop.gremlin.console.Console %*
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.console.Console %*
 
-set CLASSPATH=%OLD_CLASSPATH%
-goto :eof
+GOTO finally
+
+:: Evaluate a Groovy script file
 
 :script
 
-set strg=
+SET strg=
 
 FOR %%X IN (%*) DO (
 CALL :concat %%X %1 %2
 )
 
-set CLASSPATH=%CP%;%OLD_CLASSPATH%
-java %JAVA_OPTIONS% %JAVA_ARGS% org.apache.tinkerpop.gremlin.groovy.jsr223.ScriptExecutor %strg%
-set CLASSPATH=%OLD_CLASSPATH%
-goto :eof
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.groovy.jsr223.ScriptExecutor %strg%
+
+GOTO finally
+
+:: Print the version
 
 :version
 
-set CLASSPATH=%CP%;%OLD_CLASSPATH%
-java %JAVA_OPTIONS% %JAVA_ARGS% org.apache.tinkerpop.gremlin.util.Gremlin
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.util.Gremlin
 
-set CLASSPATH=%OLD_CLASSPATH%
-goto :eof
+GOTO finally
+
 
 :concat
 
-if %1 == %2 goto skip
+IF %1 == %2 GOTO finally
 
 SET strg=%strg% %1
 
-:concatsep
 
-if "%CP%" == "" (
-set CP=%LIBDIR%\%1
-)else (
-set CP=%CP%;%LIBDIR%\%1
-)
+:finally
 
-:skip
+ENDLOCAL

--- a/titan-dist/src/assembly/static/bin/gremlin.bat
+++ b/titan-dist/src/assembly/static/bin/gremlin.bat
@@ -123,7 +123,7 @@ GOTO finally
 
 :version
 
-java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% org.apache.tinkerpop.gremlin.util.Gremlin
+java %JAVA_OPTIONS% %JAVA_ARGS% -cp %CP% com.thinkaurelius.titan.core.Titan
 
 GOTO finally
 

--- a/titan-dist/src/assembly/static/bin/gremlin.sh
+++ b/titan-dist/src/assembly/static/bin/gremlin.sh
@@ -86,7 +86,7 @@ while getopts "elpv" opt; do
        ;;
     p) PROFILING_ENABLED=true
        ;;
-    v) MAIN_CLASS=org.apache.tinkerpop.gremlin.util.Gremlin
+    v) MAIN_CLASS=com.thinkaurelius.titan.core.Titan
     esac
 done
 

--- a/titan-dist/src/assembly/static/conf/logback.xml
+++ b/titan-dist/src/assembly/static/conf/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss} %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="WARN">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
https://github.com/thinkaurelius/titan/issues/1242

Fixes for `gremlin.bat` and `gremlin-server.bat` based off of the TinkerPop3 versions of those files.
- I tested on Windows 7 and Windows 10 with Cassandra 2.1.13 and Elasticsearch 1.5.2 local on the Windows machine
- I tested OLAP traversals (Gryo-based) against a remote Linux-based HDFS/YARN/Spark cluster
- I tested passing scripts in with `gremlin.bat -e`
- I tested installing plugins with `gremlin-server.bat -i`
- I did not test OLAP against a Windows HDFS/YARN/Spark cluster. It became too much trouble to install -- do people really run Hadoop on Windows :)

I included a `logback.xml` more as an example, but it doesn't get used since the scripts force log4j ahead of it on the classpath.

It would be simpler to pull in the `winutils.exe` directly into the build, but I imagine that could complicate licensing concerns.

I didn't tackle a conversion of `titan.sh` to `titan.bat` with this PR. I'll open up a separate issue for that. Another separate issue would be adding more Titan-specific support for `gremlin.bat -v`.
