### PR TITLE
made optimistic locking a store feature

### DIFF
--- a/titan-berkeleyje/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
+++ b/titan-berkeleyje/src/main/java/com/thinkaurelius/titan/diskstorage/berkeleyje/BerkeleyJEStoreManager.java
@@ -73,6 +73,7 @@ public class BerkeleyJEStoreManager extends LocalStoreManager implements Ordered
                     .keyConsistent(GraphDatabaseConfiguration.buildGraphConfiguration())
                     .locking(true)
                     .keyOrdered(true)
+                    .optimisticLocking(false)
                     .scanTxConfig(GraphDatabaseConfiguration.buildGraphConfiguration()
                             .set(ISOLATION_LEVEL, IsolationLevel.READ_UNCOMMITTED.toString()))
                     .supportsInterruption(false)

--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/graphdb/berkeleyje/BerkeleyGraphTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/graphdb/berkeleyje/BerkeleyGraphTest.java
@@ -70,11 +70,6 @@ public class BerkeleyGraphTest extends TitanGraphTest {
     }
 
     @Override
-    protected boolean isLockingOptimistic() {
-        return false;
-    }
-
-    @Override
     public void testConcurrentConsistencyEnforcement() {
         //Do nothing TODO: Figure out why this is failing in BerkeleyDB!!
     }

--- a/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
+++ b/titan-cassandra/src/main/java/com/thinkaurelius/titan/diskstorage/cassandra/AbstractCassandraStoreManager.java
@@ -264,6 +264,7 @@ public abstract class AbstractCassandraStoreManager extends DistributedStoreMana
             fb.batchMutation(true).distributed(true);
             fb.timestamps(true).cellTTL(true);
             fb.keyConsistent(global, local);
+            fb.optimisticLocking(true);
 
             boolean keyOrdered;
 

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/CassandraGraphTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/CassandraGraphTest.java
@@ -24,11 +24,6 @@ public abstract class CassandraGraphTest extends TitanGraphTest {
         CassandraStorageSetup.startCleanEmbedded();
     }
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
     @Test
     public void testHasTTL() throws Exception {
         assertTrue(features.hasCellTTL());

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ThriftGraphCacheTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ThriftGraphCacheTest.java
@@ -19,10 +19,4 @@ public class ThriftGraphCacheTest extends TitanGraphTest {
         CassandraStorageSetup.startCleanEmbedded();
     }
 
-
-
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StandardStoreFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StandardStoreFeatures.java
@@ -12,6 +12,7 @@ public class StandardStoreFeatures implements StoreFeatures {
     private final boolean orderedScan;
     private final boolean multiQuery;
     private final boolean locking;
+    private final boolean optimisticLocking;
     private final boolean batchMutation;
     private final boolean localKeyPartition;
     private final boolean keyOrdered;
@@ -52,6 +53,11 @@ public class StandardStoreFeatures implements StoreFeatures {
     @Override
     public boolean hasLocking() {
         return locking;
+    }
+
+    @Override
+    public boolean isLockingOptimistic() {
+        return optimisticLocking;
     }
 
     @Override
@@ -142,6 +148,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         private boolean orderedScan;
         private boolean multiQuery;
         private boolean locking;
+        private boolean optimisticLocking;
         private boolean batchMutation;
         private boolean localKeyPartition;
         private boolean keyOrdered;
@@ -208,6 +215,11 @@ public class StandardStoreFeatures implements StoreFeatures {
 
         public Builder locking(boolean b) {
             locking = b;
+            return this;
+        }
+
+        public Builder optimisticLocking(boolean b) {
+            optimisticLocking = b;
             return this;
         }
 
@@ -298,7 +310,7 @@ public class StandardStoreFeatures implements StoreFeatures {
 
         public StandardStoreFeatures build() {
             return new StandardStoreFeatures(unorderedScan, orderedScan,
-                    multiQuery, locking, batchMutation, localKeyPartition,
+                    multiQuery, locking, optimisticLocking, batchMutation, localKeyPartition,
                     keyOrdered, distributed, transactional, keyConsistent,
                     timestamps, preferredTimestamps, cellLevelTTL,
                     storeLevelTTL, visibility, supportsPersist,
@@ -308,7 +320,7 @@ public class StandardStoreFeatures implements StoreFeatures {
     }
 
     private StandardStoreFeatures(boolean unorderedScan, boolean orderedScan,
-            boolean multiQuery, boolean locking, boolean batchMutation,
+            boolean multiQuery, boolean locking, boolean optimisticLocking, boolean batchMutation,
             boolean localKeyPartition, boolean keyOrdered, boolean distributed,
             boolean transactional, boolean keyConsistent,
             boolean timestamps, TimestampProviders preferredTimestamps,
@@ -321,6 +333,7 @@ public class StandardStoreFeatures implements StoreFeatures {
         this.orderedScan = orderedScan;
         this.multiQuery = multiQuery;
         this.locking = locking;
+        this.optimisticLocking = optimisticLocking;
         this.batchMutation = batchMutation;
         this.localKeyPartition = localKeyPartition;
         this.keyOrdered = keyOrdered;

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StoreFeatures.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/StoreFeatures.java
@@ -45,6 +45,12 @@ public interface StoreFeatures {
     public boolean hasLocking();
 
     /**
+      * Whether this store uses optimistic locking.
+      * @return
+      */
+    public boolean isLockingOptimistic();
+
+    /**
      * Whether this storage backend supports batch mutations via
      * {@link KeyColumnValueStoreManager#mutateMany(java.util.Map, StoreTransaction)}.
      *

--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/keycolumnvalue/inmemory/InMemoryStoreManager.java
@@ -40,6 +40,7 @@ public class InMemoryStoreManager implements KeyColumnValueStoreManager {
             .keyOrdered(true)
             .persists(false)
             .keyConsistent(GraphDatabaseConfiguration.buildGraphConfiguration())
+            .optimisticLocking(true)
             .build();
 
 //        features = new StoreFeatures();

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -1692,6 +1692,10 @@ public class GraphDatabaseConfiguration {
         return batchLoading;
     }
 
+    public boolean isOptimisticLocking() {
+        return getStoreFeatures().isLockingOptimistic();
+    }
+
     public String getUniqueGraphId() {
         return uniqueGraphId;
     }

--- a/titan-hbase-parent/titan-hbase-core/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
+++ b/titan-hbase-parent/titan-hbase-core/src/main/java/com/thinkaurelius/titan/diskstorage/hbase/HBaseStoreManager.java
@@ -383,7 +383,7 @@ public class HBaseStoreManager extends DistributedStoreManager implements KeyCol
                 .orderedScan(true).unorderedScan(true).batchMutation(true)
                 .multiQuery(true).distributed(true).keyOrdered(true).storeTTL(true)
                 .timestamps(true).preferredTimestamps(PREFERRED_TIMESTAMPS)
-                .keyConsistent(c);
+                .keyConsistent(c).optimisticLocking(true);
 
         try {
             fb.localKeyPartition(getDeployment() == Deployment.LOCAL);

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/graphdb/hbase/HBaseGraphTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/graphdb/hbase/HBaseGraphTest.java
@@ -28,9 +28,4 @@ public class HBaseGraphTest extends TitanGraphTest {
         return HBaseStorageSetup.getHBaseGraphConfiguration();
     }
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
 }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanGraphTest.java
@@ -154,7 +154,9 @@ public abstract class TitanGraphTest extends TitanGraphBaseTest {
 
     private Logger log = LoggerFactory.getLogger(TitanGraphTest.class);
 
-    protected abstract boolean isLockingOptimistic();
+    private final boolean isLockingOptimistic() {
+        return ((StandardTitanGraph) graph).getBackend().getStoreManager().getFeatures().isLockingOptimistic();
+    }
 
   /* ==================================================================================
                             INDEXING

--- a/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryGraphTest.java
+++ b/titan-test/src/test/java/com/thinkaurelius/titan/graphdb/inmemory/InMemoryGraphTest.java
@@ -85,9 +85,4 @@ public class InMemoryGraphTest extends TitanGraphTest {
     @Override
     public void testIndexUpdateSyncWithMultipleInstances() {}
 
-    @Override
-    protected boolean isLockingOptimistic() {
-        return true;
-    }
-
 }


### PR DESCRIPTION
old PR https://github.com/thinkaurelius/titan/pull/1140

Question from old PR: Is there a need to update Chapter 12 of the documents to explain how this is defaulted and configured now?

Currently, the optimistic locking behaviour is hardcoded into each storage backend and is not something configurable. It is conceivable that you could fork titan-cassandra or dynamodb-titan100-storage-backend and make the timestamp-based locking in Cassandra or the current value-based locking configurable (ie, turn it off), but the effect of this would be to disable locking, so making the optimisticLocking store feature configurable is moot.
