### PR TITLE
Allow custom vertex id in TitanBlueprintsTransaction when graph.set-vertex-id=true

### DIFF
--- a/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
+++ b/titan-berkeleyje/src/test/java/com/thinkaurelius/titan/graphdb/berkeleyje/BerkeleyOperationCountingTest.java
@@ -2,7 +2,6 @@ package com.thinkaurelius.titan.graphdb.berkeleyje;
 
 import com.thinkaurelius.titan.BerkeleyStorageSetup;
 import com.thinkaurelius.titan.diskstorage.configuration.WriteConfiguration;
-import com.thinkaurelius.titan.graphdb.TitanGraphTest;
 import com.thinkaurelius.titan.graphdb.TitanOperationCountingTest;
 
 public class BerkeleyOperationCountingTest extends TitanOperationCountingTest {
@@ -10,11 +9,6 @@ public class BerkeleyOperationCountingTest extends TitanOperationCountingTest {
     @Override
     public WriteConfiguration getBaseConfiguration() {
         return BerkeleyStorageSetup.getBerkeleyJEGraphConfiguration();
-    }
-
-    @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return false;
     }
 
 }

--- a/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ThriftOperationCountingTest.java
+++ b/titan-cassandra/src/test/java/com/thinkaurelius/titan/graphdb/thrift/ThriftOperationCountingTest.java
@@ -17,9 +17,4 @@ public class ThriftOperationCountingTest extends TitanOperationCountingTest {
         return CassandraStorageSetup.getCassandraThriftGraphConfiguration(getClass().getSimpleName());
     }
 
-    @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return true;
-    }
-
 }

--- a/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsTransaction.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsTransaction.java
@@ -5,6 +5,7 @@ import com.thinkaurelius.titan.core.TitanTransaction;
 import com.thinkaurelius.titan.core.TitanVertex;
 import com.thinkaurelius.titan.core.VertexLabel;
 import com.thinkaurelius.titan.diskstorage.util.Hex;
+import com.thinkaurelius.titan.graphdb.database.StandardTitanGraph;
 import com.thinkaurelius.titan.graphdb.olap.computer.FulgoraGraphComputer;
 import com.thinkaurelius.titan.graphdb.relations.RelationIdentifier;
 import com.thinkaurelius.titan.graphdb.types.system.BaseVertexLabel;
@@ -87,7 +88,7 @@ public abstract class TitanBlueprintsTransaction implements TitanTransaction {
     @Override
     public TitanVertex addVertex(Object... keyValues) {
         ElementHelper.legalPropertyKeyValueArray(keyValues);
-        if (ElementHelper.getIdValue(keyValues).isPresent()) throw Vertex.Exceptions.userSuppliedIdsNotSupported();
+        if (ElementHelper.getIdValue(keyValues).isPresent() && !((StandardTitanGraph) getGraph()).getConfiguration().allowVertexIdSetting()) throw Vertex.Exceptions.userSuppliedIdsNotSupported();
         Object labelValue = null;
         for (int i = 0; i < keyValues.length; i = i + 2) {
             if (keyValues[i].equals(T.label)) {

--- a/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/graphdb/hbase/HBaseOperationCountingTest.java
+++ b/titan-hbase-parent/titan-hbase-core/src/test/java/com/thinkaurelius/titan/graphdb/hbase/HBaseOperationCountingTest.java
@@ -33,11 +33,6 @@ public class HBaseOperationCountingTest extends TitanOperationCountingTest {
     }
 
     @Override
-    public boolean storeUsesConsistentKeyLocker() {
-        return true;
-    }
-
-    @Override
     public void testCacheConcurrency() throws InterruptedException {
         //Don't run this test;
     }

--- a/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanOperationCountingTest.java
+++ b/titan-test/src/main/java/com/thinkaurelius/titan/graphdb/TitanOperationCountingTest.java
@@ -57,7 +57,9 @@ public abstract class TitanOperationCountingTest extends TitanGraphBaseTest {
 
     public abstract WriteConfiguration getBaseConfiguration();
 
-    public abstract boolean storeUsesConsistentKeyLocker();
+    public boolean storeUsesConsistentKeyLocker() {
+        return !features.hasLocking();
+    }
 
     @Override
     public WriteConfiguration getConfiguration() {


### PR DESCRIPTION
The following TitanVertexFeature suggests that the use of custom vertex ids through TinkerPop Structure depends on the allowVertexIdSetting() value:
https://github.com/thinkaurelius/titan/blob/titan11/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanFeatures.java#L173

However the TitanBlueprintsTransaction implementation forbids custom ids regardless of the allowVertexIdSetting():
https://github.com/thinkaurelius/titan/blob/titan11/titan-core/src/main/java/com/thinkaurelius/titan/graphdb/tinkerpop/TitanBlueprintsTransaction.java#L90

Making me drill down to vendor-specific implementation to use custom vertex ids even though they should be supported, like this:
https://github.com/classmethod/tupl-titan-storage-backend/blob/titan10/src/test/java/jp/classmethod/titan/TuplStorageSetup.java#L100

Even though I should be able to use graph.addVertex(T.id, titanVertexId, T.label, label, NODE_ID, longVal) because I have enabled setting vertex IDs:
https://github.com/classmethod/tupl-titan-storage-backend/blob/titan10/src/test/java/jp/classmethod/titan/TuplStorageSetup.java#L124
