### PR TITLE
Fixes #1340. Correct name of storage.hbase.ext

### DIFF
--- a/docs/hbase.txt
+++ b/docs/hbase.txt
@@ -86,7 +86,7 @@ When configuring HBase it is recommended to consider the following HBase specifi
 
 * *tablename*: Name of the HBase table in which to store the Titan graph. Allows multiple Titan graphs to co-exist in the same HBase cluster.
 
-Please refer to the http://hbase.apache.org/book/config.files.html[HBase configuration documentation] for more HBase configuration options and their description. By prefixing the respective HBase configuration option with `storage.hbase-config` in the Titan configuration it will be passed on to HBase at initialization time. This allows arbitrary HBase configuration options to be configured through Titan.
+Please refer to the http://hbase.apache.org/book/config.files.html[HBase configuration documentation] for more HBase configuration options and their description. By prefixing the respective HBase configuration option with `storage.hbase.ext` in the Titan configuration it will be passed on to HBase at initialization time. This allows arbitrary HBase configuration options to be configured through Titan.
 
 Global Graph Operations
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The storage.hbase-config parameter was changed to storage.hbase.ext in the source code but not in the documentation.
