### PR TITLE
Fix ConsistentKeyIDAuthority format string

### DIFF
--- a/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/idmanagement/ConsistentKeyIDAuthority.java
+++ b/titan-core/src/main/java/com/thinkaurelius/titan/diskstorage/idmanagement/ConsistentKeyIDAuthority.java
@@ -345,7 +345,7 @@ public class ConsistentKeyIDAuthority extends AbstractIDAuthority implements Bac
             }
         }
 
-        throw new TemporaryLockingException(String.format("Reached timeout %d (%s elapsed) when attempting to allocate id block on partition(%d)-namespace(%d)",
+        throw new TemporaryLockingException(String.format("Reached timeout %s (%s elapsed) when attempting to allocate id block on partition(%d)-namespace(%d)",
                 timeout, methodTime.toString(), partition, idNamespace));
     }
 


### PR DESCRIPTION
Previously the formatter %d was used for a java.time.Duration. When this code gets executed, instead of throwing the TemporaryLockingException, it would instead throw an IllegalFormatConversionException with the message "d != java.time.Duration".
