### PR TITLE
fix(sec): upgrade org.apache.solr:solr-core to 8.11.1

### DIFF
--- a/titan-solr/pom.xml
+++ b/titan-solr/pom.xml
@@ -11,7 +11,7 @@
     <url>http://thinkaurelius.github.com/titan/</url>
     <properties>
         <top.level.basedir>${basedir}/..</top.level.basedir>
-        <solr.version>5.2.1</solr.version>
+        <solr.version>8.11.1</solr.version>
         <zookeeper.version>3.4.6</zookeeper.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.solr:solr-core 5.2.1
- [CVE-2021-27905](https://www.oscs1024.com/hd/CVE-2021-27905)


### What did I do？
Upgrade org.apache.solr:solr-core from 5.2.1 to 8.11.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS